### PR TITLE
Applying Spec recommendations

### DIFF
--- a/src/bit.rs
+++ b/src/bit.rs
@@ -3,23 +3,25 @@
 //! These tool support both the prefered deliniarized as well as the
 //! discuraged proof-of-possession flavors of aggregation.
 
+use core::borrow::{Borrow, BorrowMut};
+use core::iter::once;
 
-use core::borrow::{Borrow,BorrowMut};
-use core::iter::{once};
+use ark_ec::Group;
+use ark_ff::Zero;
 
-use ark_ff::{Zero};
-use ark_ec::{Group};
-
-use super::*;
 use super::single::SignedMessage;
 use super::verifiers::verify_with_distinct_messages;
-
+use super::*;
 
 // Slice equality with bytewise equality hack because
 // std does not expose `slice::BytewiseEquality`
 fn slice_eq_bytewise<T: PartialEq<T>>(x: &[T], y: &[T]) -> bool {
-    if x.len() != y.len() { return false; }
-    if ::core::ptr::eq(x,y) { return true; }
+    if x.len() != y.len() {
+        return false;
+    }
+    if ::core::ptr::eq(x, y) {
+        return true;
+    }
     x == y
 }
 
@@ -37,7 +39,7 @@ pub trait SignerTable<E: EngineBLS> {
     /// Bitfield type used to represent a signers set
     ///
     /// Must not permit altering length, so `Box<[u8]>` or `[u8; 128]` not `Vec<u8>`.
-    type Signers: Borrow<[u8]>+BorrowMut<[u8]>+Clone+Sized;
+    type Signers: Borrow<[u8]> + BorrowMut<[u8]> + Clone + Sized;
     /// Create a new signers set bitfield
     fn new_signers(&self) -> Self::Signers;
 
@@ -53,24 +55,28 @@ pub trait SignerTable<E: EngineBLS> {
     /// Find the bit index for a particular public key.
     ///
     /// Must succeed if the public key is present, and fail otherwise.
-    /// 
+    ///
     /// Must satisfy `self.find(pk).and_then(|i| self.lookup(i)) == Some(pk)` when `pk` is present.
     fn find(&self, publickey: &PublicKey<E>) -> Option<usize>;
 }
 
 /// Occupied indices bit mask for `self.signers[offset]`  
-fn chunk_lookups<E,ST>(signer_table: &ST, offset: usize) -> u8 
-where E: EngineBLS, ST: SignerTable<E>
+fn chunk_lookups<E, ST>(signer_table: &ST, offset: usize) -> u8
+where
+    E: EngineBLS,
+    ST: SignerTable<E>,
 {
-    (0..8).into_iter().fold(0u8, |b,j| {
-        let i = 8*offset + j;
-        let pk = signer_table.lookup(i)
-            .filter(|pk| {
-                // bb = true always due to check in add_points
-                let bb = Some(i) == signer_table.find(&pk);
-                debug_assert!(bb , "Incorrect SignerTable implementation with duplicate publickeys" );
-                bb
-            });
+    (0..8).into_iter().fold(0u8, |b, j| {
+        let i = 8 * offset + j;
+        let pk = signer_table.lookup(i).filter(|pk| {
+            // bb = true always due to check in add_points
+            let bb = Some(i) == signer_table.find(&pk);
+            debug_assert!(
+                bb,
+                "Incorrect SignerTable implementation with duplicate publickeys"
+            );
+            bb
+        });
         b | pk.map_or(0u8, |_| 1u8 << j)
     })
 }
@@ -80,13 +86,13 @@ where E: EngineBLS, ST: SignerTable<E>
 ///
 /// TODO: Evaluate using Deref vs Borrow in this context
 /// TODO: Use specialization here
-impl<E,V> SignerTable<E> for V
+impl<E, V> SignerTable<E> for V
 where
     E: EngineBLS,
-    V: ::core::ops::Deref<Target=[PublicKey<E>]>
+    V: ::core::ops::Deref<Target = [PublicKey<E>]>,
 {
     fn agreement(&self, other: &Self) -> bool {
-        slice_eq_bytewise(self.deref(),other.deref())
+        slice_eq_bytewise(self.deref(), other.deref())
     }
 
     type Signers = Box<[u8]>;
@@ -104,7 +110,7 @@ where
         // })
     }
     fn find(&self, publickey: &PublicKey<E>) -> Option<usize> {
-        self.deref().iter().position(|pk| *pk==*publickey)
+        self.deref().iter().position(|pk| *pk == *publickey)
         // Checked for duplicates in BitSignedMessage
         // .filter(|index| {
         //     Some(publickey) == self.deref().get(index);
@@ -121,9 +127,9 @@ where
 /// impossible nomrally.
 #[derive(Debug)]
 pub enum SignerTableError {
-    /// Attempted to use missmatched proof-of-possession tables. 
+    /// Attempted to use missmatched proof-of-possession tables.
     BadSignerTable(&'static str),
-    /// Attempted to aggregate distint messages, which requires the 
+    /// Attempted to aggregate distint messages, which requires the
     /// the more general SignatureAggregatorAssumingPoP type instead.
     MismatchedMessage,
     /// Aggregation is impossible due to signers being repeated or
@@ -136,7 +142,10 @@ impl ::core::fmt::Display for SignerTableError {
         use self::SignerTableError::*;
         match self {
             BadSignerTable(s) => write!(f, "{}", s),
-            MismatchedMessage => write!(f, "Cannot aggregate distinct messages with only a bit field."),
+            MismatchedMessage => write!(
+                f,
+                "Cannot aggregate distinct messages with only a bit field."
+            ),
             RepeatedSigners => write!(f, "Cannot aggregate due to duplicate signers."),
         }
     }
@@ -172,22 +181,22 @@ pub struct BitSignedMessage<E: EngineBLS, POP: SignerTable<E>> {
     signature: Signature<E>,
 }
 
-impl<'a,E,POP> Clone for BitSignedMessage<E,POP>
-where 
+impl<'a, E, POP> Clone for BitSignedMessage<E, POP>
+where
     E: EngineBLS,
-    POP: SignerTable<E>+Clone,
+    POP: SignerTable<E> + Clone,
 {
-    fn clone(&self) -> BitSignedMessage<E,POP> {
+    fn clone(&self) -> BitSignedMessage<E, POP> {
         BitSignedMessage {
             proofs_of_possession: self.proofs_of_possession.clone(),
             signers: self.signers.clone(),
-            message: self.message,
+            message: self.message.clone(),
             signature: self.signature.clone(),
         }
     }
 }
 
-impl<'a,E,POP> Signed for &'a BitSignedMessage<E,POP> 
+impl<'a, E, POP> Signed for &'a BitSignedMessage<E, POP>
 where
     E: EngineBLS,
     POP: SignerTable<E>,
@@ -201,12 +210,15 @@ where
 
     fn messages_and_publickeys(self) -> Self::PKnM {
         let mut publickey = E::PublicKeyGroup::zero();
-        for i in 0..8*self.signers.borrow().len() {
+        for i in 0..8 * self.signers.borrow().len() {
             if self.signers.borrow()[i / 8] & (1 << (i % 8)) != 0 {
                 let pop_pk = self.proofs_of_possession.lookup(i).unwrap();
                 if Some(i) != self.proofs_of_possession.find(&pop_pk) {
                     // unreachable due to check in add points
-                    debug_assert!(false, "Incorrect SignerTable implementation with duplicate publickeys" );
+                    debug_assert!(
+                        false,
+                        "Incorrect SignerTable implementation with duplicate publickeys"
+                    );
                     continue;
                 }
                 publickey += &pop_pk.0;
@@ -215,38 +227,57 @@ where
         once((self.message.clone(), PublicKey(publickey)))
     }
 
-    fn signature(&self) -> Signature<E> { self.signature }
+    fn signature(&self) -> Signature<E> {
+        self.signature
+    }
 
     fn verify(self) -> bool {
         // We have already aggregated distinct messages, so our distinct
         // message verification code provides reasonable optimizations,
-        // except the public keys need not be normalized here. 
+        // except the public keys need not be normalized here.
         // We foresee verification via gaussian elimination being
         // significantly faster, but requiring affine keys.
-        verify_with_distinct_messages(self,true)
+        verify_with_distinct_messages(self, true)
     }
 }
 
-impl<E,POP> BitSignedMessage<E,POP> 
+impl<E, POP> BitSignedMessage<E, POP>
 where
     E: EngineBLS,
     POP: SignerTable<E>,
 {
-    pub fn new(proofs_of_possession: POP, message: Message) -> BitSignedMessage<E,POP> {
+    pub fn new(proofs_of_possession: POP, message: &Message) -> BitSignedMessage<E, POP> {
         let signers = proofs_of_possession.new_signers();
         let signature = Signature(E::SignatureGroup::zero());
-        BitSignedMessage { proofs_of_possession, signers, message, signature }
+        BitSignedMessage {
+            proofs_of_possession,
+            signers,
+            message: message.clone(),
+            signature,
+        }
     }
 
-    fn add_points(&mut self, publickey: PublicKey<E>, signature: Signature<E>) -> Result<(),SignerTableError> {
-        let i = self.proofs_of_possession.find(&publickey)
-            .ok_or(SignerTableError::BadSignerTable("Mismatched proof-of-possession")) ?;
+    fn add_points(
+        &mut self,
+        publickey: PublicKey<E>,
+        signature: Signature<E>,
+    ) -> Result<(), SignerTableError> {
+        let i =
+            self.proofs_of_possession
+                .find(&publickey)
+                .ok_or(SignerTableError::BadSignerTable(
+                    "Mismatched proof-of-possession",
+                ))?;
         if self.proofs_of_possession.lookup(i) != Some(publickey) {
-            return Err(SignerTableError::BadSignerTable("Invalid SignerTable implementation with missmatched lookups"));
+            return Err(SignerTableError::BadSignerTable(
+                "Invalid SignerTable implementation with missmatched lookups",
+            ));
         }
         let b = 1 << (i % 8);
         let s = &mut self.signers.borrow_mut()[i / 8];
-        if *s & b != 0 { return Err(SignerTableError::RepeatedSigners); }
+        if *s & b != 0 {
+            return Err(SignerTableError::RepeatedSigners);
+        }
         *s |= b;
         self.signature.0 += &signature.0;
         Ok(())
@@ -254,37 +285,53 @@ where
 
     /// Include one signed message, after testing for message and
     /// proofs-of-possession table agreement, and disjoint publickeys.
-    pub fn add(&mut self, signed: &SignedMessage<E>) -> Result<(),SignerTableError>
-    {
+    pub fn add(&mut self, signed: &SignedMessage<E>) -> Result<(), SignerTableError> {
         if self.message != signed.message {
             return Err(SignerTableError::MismatchedMessage);
         }
-        self.add_points(signed.publickey,signed.signature)
+        self.add_points(signed.publickey, signed.signature)
     }
 
     /// Merge two `BitSignedMessage`, after testing for message
     /// and proofs-of-possession table agreement, and disjoint publickeys.
-    pub fn merge(&mut self, other: &BitSignedMessage<E,POP>) -> Result<(),SignerTableError> {
+    pub fn merge(&mut self, other: &BitSignedMessage<E, POP>) -> Result<(), SignerTableError> {
         if self.message != other.message {
             return Err(SignerTableError::MismatchedMessage);
         }
-        if ! self.proofs_of_possession.agreement(&other.proofs_of_possession) {
-            return Err(SignerTableError::BadSignerTable("Mismatched proof-of-possession"));
+        if !self
+            .proofs_of_possession
+            .agreement(&other.proofs_of_possession)
+        {
+            return Err(SignerTableError::BadSignerTable(
+                "Mismatched proof-of-possession",
+            ));
         }
-        for (offset,(x,y)) in self.signers.borrow().iter().zip(other.signers.borrow()).enumerate() {
-            if *x & *y != 0 { return Err(SignerTableError::RepeatedSigners); }
-            if *y & ! chunk_lookups(&self.proofs_of_possession, offset) != 0 {
+        for (offset, (x, y)) in self
+            .signers
+            .borrow()
+            .iter()
+            .zip(other.signers.borrow())
+            .enumerate()
+        {
+            if *x & *y != 0 {
+                return Err(SignerTableError::RepeatedSigners);
+            }
+            if *y & !chunk_lookups(&self.proofs_of_possession, offset) != 0 {
                 return Err(SignerTableError::BadSignerTable("Absent signer"));
             }
         }
-        for (x,y) in self.signers.borrow_mut().iter_mut().zip(other.signers.borrow()) {
+        for (x, y) in self
+            .signers
+            .borrow_mut()
+            .iter_mut()
+            .zip(other.signers.borrow())
+        {
             *x |= y;
         }
         self.signature.0 += &other.signature.0;
         Ok(())
     }
 }
-
 
 /// One individual message with attached aggreggate BLS signatures
 /// from signers for whom we previously checked proofs-of-possession,
@@ -308,23 +355,23 @@ pub struct CountSignedMessage<E: EngineBLS, POP: SignerTable<E>> {
     pub max_duplicates: usize,
 }
 
-impl<'a,E,POP> Clone for CountSignedMessage<E,POP>
-where 
+impl<'a, E, POP> Clone for CountSignedMessage<E, POP>
+where
     E: EngineBLS,
-    POP: SignerTable<E>+Clone,
+    POP: SignerTable<E> + Clone,
 {
-    fn clone(&self) -> CountSignedMessage<E,POP> {
+    fn clone(&self) -> CountSignedMessage<E, POP> {
         CountSignedMessage {
             proofs_of_possession: self.proofs_of_possession.clone(),
             signers: self.signers.clone(),
-            message: self.message,
+            message: self.message.clone(),
             signature: self.signature.clone(),
             max_duplicates: self.max_duplicates,
         }
     }
 }
 
-impl<'a,E,POP> Signed for &'a CountSignedMessage<E,POP> 
+impl<'a, E, POP> Signed for &'a CountSignedMessage<E, POP>
 where
     E: EngineBLS,
     POP: SignerTable<E>,
@@ -340,12 +387,15 @@ where
         let mut publickey = E::PublicKeyGroup::zero();
         for signers in self.signers.iter().rev().map(|signers| signers.borrow()) {
             publickey.double_in_place();
-            for i in 0..8*signers.len() {
+            for i in 0..8 * signers.len() {
                 if signers[i / 8] & (1 << (i % 8)) != 0 {
                     let pop_pk = self.proofs_of_possession.lookup(i).unwrap();
                     if Some(i) != self.proofs_of_possession.find(&pop_pk) {
                         // unreachable due to check in add points
-                        debug_assert!(false, "Incorrect SignerTable implementation with duplicate publickeys" );
+                        debug_assert!(
+                            false,
+                            "Incorrect SignerTable implementation with duplicate publickeys"
+                        );
                         continue;
                     }
                     publickey += &pop_pk.0;
@@ -355,28 +405,36 @@ where
         once((self.message.clone(), PublicKey(publickey)))
     }
 
-    fn signature(&self) -> Signature<E> { self.signature }
+    fn signature(&self) -> Signature<E> {
+        self.signature
+    }
 
     fn verify(self) -> bool {
         // We have already aggregated distinct messages, so our distinct
         // message verification code provides reasonable optimizations,
-        // except the public keys need not be normalized here. 
+        // except the public keys need not be normalized here.
         // We foresee verification via gaussian elimination being
         // significantly faster, but requiring affine keys.
-        verify_with_distinct_messages(self,true)
+        verify_with_distinct_messages(self, true)
     }
 }
 
-impl<E,POP> CountSignedMessage<E,POP> 
+impl<E, POP> CountSignedMessage<E, POP>
 where
     E: EngineBLS,
     POP: SignerTable<E>,
 {
-    pub fn new(proofs_of_possession: POP, message: Message) -> CountSignedMessage<E,POP> {
+    pub fn new(proofs_of_possession: POP, message: Message) -> CountSignedMessage<E, POP> {
         let signers = vec![proofs_of_possession.new_signers(); 1];
         let signature = Signature(E::SignatureGroup::zero());
         let max_duplicates = 16;
-        CountSignedMessage { proofs_of_possession, signers, message, signature, max_duplicates }
+        CountSignedMessage {
+            proofs_of_possession,
+            signers,
+            message,
+            signature,
+            max_duplicates,
+        }
     }
 
     /*
@@ -390,7 +448,9 @@ where
 
     fn reserve_depth(&mut self, count: usize) {
         let l = 0usize.leading_zeros() - count.leading_zeros();
-        if l as usize <= self.signers.len() { return; }
+        if l as usize <= self.signers.len() {
+            return;
+        }
         let l = l as usize - self.signers.len();
         self.signers.reserve(l);
         for _i in 0..l {
@@ -407,7 +467,7 @@ where
         self.signers.truncate(c)
     }*/
 
-    fn test_count(&self, count: usize) -> Result<(),SignerTableError> {
+    fn test_count(&self, count: usize) -> Result<(), SignerTableError> {
         if count >= self.max_duplicates || count >= usize::max_value() {
             return Err(SignerTableError::RepeatedSigners);
         }
@@ -427,67 +487,87 @@ where
     }
 
     /// Set the count of the number of duplicate signatures by the public key with a given index.
-    /// Always call test_count before invoking this method. 
+    /// Always call test_count before invoking this method.
     fn set_count(&mut self, index: usize, mut count: usize) {
         self.reserve_depth(count);
         for signers in self.signers.iter_mut().map(|signers| signers.borrow_mut()) {
             if count & 1usize != 0 {
                 signers[index / 8] |= 1 << (index % 8);
             } else {
-                signers[index / 8] &= ! (1 << (index % 8));
+                signers[index / 8] &= !(1 << (index % 8));
             }
             count /= 2;
         }
     }
 
-
-    fn add_points(&mut self, publickey: PublicKey<E>, signature: Signature<E>) -> Result<(),SignerTableError> {
-        let i = self.proofs_of_possession.find(&publickey)
-            .ok_or(SignerTableError::BadSignerTable("Mismatched proof-of-possession")) ?;
+    fn add_points(
+        &mut self,
+        publickey: PublicKey<E>,
+        signature: Signature<E>,
+    ) -> Result<(), SignerTableError> {
+        let i =
+            self.proofs_of_possession
+                .find(&publickey)
+                .ok_or(SignerTableError::BadSignerTable(
+                    "Mismatched proof-of-possession",
+                ))?;
         if self.proofs_of_possession.lookup(i) != Some(publickey) {
-            return Err(SignerTableError::BadSignerTable("Invalid SignerTable implementation with missmatched lookups"));
+            return Err(SignerTableError::BadSignerTable(
+                "Invalid SignerTable implementation with missmatched lookups",
+            ));
         }
         let count = self.get_count(i) + 1;
-        self.test_count(count) ?;
-        self.set_count(i,count);
+        self.test_count(count)?;
+        self.set_count(i, count);
         self.signature.0 += &signature.0;
         Ok(())
     }
 
     /// Include one signed message, after testing for message and
     /// proofs-of-possession table agreement, and disjoint publickeys.
-    pub fn add(&mut self, signed: &SignedMessage<E>) -> Result<(),SignerTableError>
-    {
+    pub fn add(&mut self, signed: &SignedMessage<E>) -> Result<(), SignerTableError> {
         if self.message != signed.message {
             return Err(SignerTableError::MismatchedMessage);
         }
-        self.add_points(signed.publickey,signed.signature)
+        self.add_points(signed.publickey, signed.signature)
     }
 
-
-    pub fn add_bitsig(&mut self, other: &BitSignedMessage<E,POP>) -> Result<(),SignerTableError> {
+    pub fn add_bitsig(&mut self, other: &BitSignedMessage<E, POP>) -> Result<(), SignerTableError> {
         if self.message != other.message {
             return Err(SignerTableError::MismatchedMessage);
         }
-        if ! self.proofs_of_possession.agreement(&other.proofs_of_possession) {
-            return Err(SignerTableError::BadSignerTable("Mismatched proof-of-possession"));
+        if !self
+            .proofs_of_possession
+            .agreement(&other.proofs_of_possession)
+        {
+            return Err(SignerTableError::BadSignerTable(
+                "Mismatched proof-of-possession",
+            ));
         }
         let os = other.signers.borrow();
         for offset in 0..self.signers[0].borrow().len() {
-            if self.signers.iter().fold(os[offset], |b,s| b | s.borrow()[offset]) 
-                & ! chunk_lookups(&self.proofs_of_possession, offset) != 0u8 
+            if self
+                .signers
+                .iter()
+                .fold(os[offset], |b, s| b | s.borrow()[offset])
+                & !chunk_lookups(&self.proofs_of_possession, offset)
+                != 0u8
             {
                 return Err(SignerTableError::BadSignerTable("Absent signer"));
             }
             for j in 0..8 {
-                let mut count = self.get_count(8*offset+j);
-                if os[offset] & (1 << j) != 0 { count += 1; }
-                self.test_count(count) ?;
+                let mut count = self.get_count(8 * offset + j);
+                if os[offset] & (1 << j) != 0 {
+                    count += 1;
+                }
+                self.test_count(count)?;
             }
         }
-        for index in 0..8*self.signers[0].borrow().len() {
+        for index in 0..8 * self.signers[0].borrow().len() {
             let count = self.get_count(index);
-            if os[index / 8] & (1 << (index % 8)) != 0 { self.set_count(index,count+1); }
+            if os[index / 8] & (1 << (index % 8)) != 0 {
+                self.set_count(index, count + 1);
+            }
         }
         self.signature.0 += &other.signature.0;
         Ok(())
@@ -495,86 +575,102 @@ where
 
     /// Merge two `CountSignedMessage`, after testing for message
     /// and proofs-of-possession table agreement, and disjoint publickeys.
-    pub fn merge(&mut self, other: &CountSignedMessage<E,POP>) -> Result<(),SignerTableError> {
+    pub fn merge(&mut self, other: &CountSignedMessage<E, POP>) -> Result<(), SignerTableError> {
         if self.message != other.message {
             return Err(SignerTableError::MismatchedMessage);
         }
-        if ! self.proofs_of_possession.agreement(&other.proofs_of_possession) {
-            return Err(SignerTableError::BadSignerTable("Mismatched proof-of-possession"));
+        if !self
+            .proofs_of_possession
+            .agreement(&other.proofs_of_possession)
+        {
+            return Err(SignerTableError::BadSignerTable(
+                "Mismatched proof-of-possession",
+            ));
         }
         for offset in 0..self.signers[0].borrow().len() {
-            if self.signers.iter().chain(&other.signers).fold(0u8, |b,s| b | s.borrow()[offset])
-               & ! chunk_lookups(&self.proofs_of_possession, offset) != 0u8
+            if self
+                .signers
+                .iter()
+                .chain(&other.signers)
+                .fold(0u8, |b, s| b | s.borrow()[offset])
+                & !chunk_lookups(&self.proofs_of_possession, offset)
+                != 0u8
             {
                 return Err(SignerTableError::BadSignerTable("Absent signer"));
             }
             for j in 0..8 {
-                let index = 8*offset+j;
-                self.test_count( self.get_count(index).saturating_add(other.get_count(index)) )?;
+                let index = 8 * offset + j;
+                self.test_count(self.get_count(index).saturating_add(other.get_count(index)))?;
             }
         }
-        for index in 0..8*self.signers[0].borrow().len() {
+        for index in 0..8 * self.signers[0].borrow().len() {
             self.set_count(index, self.get_count(index) + other.get_count(index));
         }
         self.signature.0 += &other.signature.0;
         Ok(())
-    }    
+    }
 }
 
-
-#[cfg(all(test, feature="std"))]
+#[cfg(all(test, feature = "std"))]
 mod tests {
-    use rand::{thread_rng};  // Rng
+    use rand::thread_rng; // Rng
 
     use super::*;
 
     #[test]
     fn proofs_of_possession() {
-        let msg1 = Message::new(b"ctx",b"some message");
-        let msg2 = Message::new(b"ctx",b"another message");
+        let msg1 = Message::new(b"ctx", b"some message");
+        let msg2 = Message::new(b"ctx", b"another message");
 
         let k = |_| Keypair::<ZBLS>::generate(thread_rng());
         let mut keypairs = (0..4).into_iter().map(k).collect::<Vec<_>>();
         let pop = keypairs.iter().map(|k| k.public).collect::<Vec<_>>();
         let dup = keypairs[3].clone();
         keypairs.push(dup);
-        let sigs1 = keypairs.iter_mut().map(|k| k.signed_message(msg1)).collect::<Vec<_>>();
+        let sigs1 = keypairs
+            .iter_mut()
+            .map(|k| k.signed_message(&msg1))
+            .collect::<Vec<_>>();
 
-        let mut bitsig1 = BitSignedMessage::<ZBLS,_>::new(pop.clone(),msg1);
-        assert!( bitsig1.verify() );  // verifiers::verify_with_distinct_messages(&dms,true)
-        for (i,sig) in sigs1.iter().enumerate().take(2) {
-            assert!( bitsig1.add(sig).is_ok() == (i<4));
-            assert!( bitsig1.verify() );  // verifiers::verify_with_distinct_messages(&dms,true)
+        let mut bitsig1 = BitSignedMessage::<ZBLS, _>::new(pop.clone(), &msg1);
+        assert!(bitsig1.verify()); // verifiers::verify_with_distinct_messages(&dms,true)
+        for (i, sig) in sigs1.iter().enumerate().take(2) {
+            assert!(bitsig1.add(sig).is_ok() == (i < 4));
+            assert!(bitsig1.verify()); // verifiers::verify_with_distinct_messages(&dms,true)
         }
-        let mut bitsig1a = BitSignedMessage::<ZBLS,_>::new(pop.clone(),msg1);
-        for (i,sig) in sigs1.iter().enumerate().skip(2) {
-            assert!( bitsig1a.add(sig).is_ok() == (i<4));
-            assert!( bitsig1a.verify() );  // verifiers::verify_with_distinct_messages(&dms,true)
+        let mut bitsig1a = BitSignedMessage::<ZBLS, _>::new(pop.clone(), &msg1);
+        for (i, sig) in sigs1.iter().enumerate().skip(2) {
+            assert!(bitsig1a.add(sig).is_ok() == (i < 4));
+            assert!(bitsig1a.verify()); // verifiers::verify_with_distinct_messages(&dms,true)
         }
-        assert!( bitsig1.merge(&bitsig1a).is_ok() );
-        assert!( bitsig1.merge(&bitsig1a).is_err() );
-        assert!( verifiers::verify_unoptimized(&bitsig1) );
-        assert!( verifiers::verify_simple(&bitsig1) );
-        assert!( verifiers::verify_with_distinct_messages(&bitsig1,false) );
+        assert!(bitsig1.merge(&bitsig1a).is_ok());
+        assert!(bitsig1.merge(&bitsig1a).is_err());
+        assert!(verifiers::verify_unoptimized(&bitsig1));
+        assert!(verifiers::verify_simple(&bitsig1));
+        assert!(verifiers::verify_with_distinct_messages(&bitsig1, false));
         // assert!( verifiers::verify_with_gaussian_elimination(&dms) );
 
-        let sigs2 = keypairs.iter_mut().map(|k| k.signed_message(msg2)).collect::<Vec<_>>();  
-        let mut bitsig2 = BitSignedMessage::<ZBLS,_>::new(pop.clone(),msg2);
+        let sigs2 = keypairs
+            .iter_mut()
+            .map(|k| k.signed_message(&msg2))
+            .collect::<Vec<_>>();
+        let mut bitsig2 = BitSignedMessage::<ZBLS, _>::new(pop.clone(), &msg2);
         for sig in sigs2.iter().take(3) {
-            assert!( bitsig2.add(sig).is_ok() );
+            assert!(bitsig2.add(sig).is_ok());
         }
-        assert!( bitsig1.merge(&bitsig2).is_err() );
+        assert!(bitsig1.merge(&bitsig2).is_err());
 
-        let mut multimsg = multi_pop_aggregator::MultiMessageSignatureAggregatorAssumingPoP::<ZBLS>::new();
+        let mut multimsg =
+            multi_pop_aggregator::MultiMessageSignatureAggregatorAssumingPoP::<ZBLS>::new();
         multimsg.aggregate(&bitsig1);
         multimsg.aggregate(&bitsig2);
-        assert!( multimsg.verify() );  // verifiers::verify_with_distinct_messages(&dms,true)
-        assert!( verifiers::verify_unoptimized(&multimsg) );
-        assert!( verifiers::verify_simple(&multimsg) );
-        assert!( verifiers::verify_with_distinct_messages(&multimsg,false) );
+        assert!(multimsg.verify()); // verifiers::verify_with_distinct_messages(&dms,true)
+        assert!(verifiers::verify_unoptimized(&multimsg));
+        assert!(verifiers::verify_simple(&multimsg));
+        assert!(verifiers::verify_with_distinct_messages(&multimsg, false));
 
-        let oops = Keypair::<ZBLS>::generate(thread_rng()).signed_message(msg2);
-        assert!( bitsig1.add_points(oops.publickey,oops.signature).is_err() );
+        let oops = Keypair::<ZBLS>::generate(thread_rng()).signed_message(&msg2);
+        assert!(bitsig1.add_points(oops.publickey, oops.signature).is_err());
         /*
         TODO: Test that adding signers for an incorrect message fails, but this version angers teh borrow checker.
         let mut oops_pop = pop.clone();
@@ -589,27 +685,29 @@ mod tests {
         assert!( ! verifiers::verify_with_distinct_messages(&bitsig1,false) );
         */
 
-        let mut countsig = CountSignedMessage::<ZBLS,_>::new(pop.clone(),msg1);
+        let mut countsig = CountSignedMessage::<ZBLS, _>::new(pop.clone(), msg1);
         assert!(countsig.signers.len() == 1);
-        assert!( countsig.verify() );  // verifiers::verify_with_distinct_messages(&dms,true)
-        assert!( countsig.add_bitsig(&bitsig1).is_ok() );
+        assert!(countsig.verify()); // verifiers::verify_with_distinct_messages(&dms,true)
+        assert!(countsig.add_bitsig(&bitsig1).is_ok());
         assert!(bitsig1.signature == countsig.signature);
         assert!(countsig.signers.len() == 1);
-        assert!(bitsig1.messages_and_publickeys().next() == countsig.messages_and_publickeys().next() );
-        assert!( countsig.verify() ); 
-        for (i,sig) in sigs1.iter().enumerate().take(3) {
-            assert!( countsig.add(sig).is_ok() == (i<4));
-            assert!( countsig.verify(), "countsig failed at sig {}",i );  // verifiers::verify_with_distinct_messages(&dms,true)
+        assert!(
+            bitsig1.messages_and_publickeys().next() == countsig.messages_and_publickeys().next()
+        );
+        assert!(countsig.verify());
+        for (i, sig) in sigs1.iter().enumerate().take(3) {
+            assert!(countsig.add(sig).is_ok() == (i < 4));
+            assert!(countsig.verify(), "countsig failed at sig {}", i); // verifiers::verify_with_distinct_messages(&dms,true)
         }
-        assert!( countsig.add_bitsig(&bitsig1a).is_ok() );
-        assert!( countsig.add_bitsig(&bitsig1a).is_ok() );
-        assert!( countsig.add_bitsig(&bitsig2).is_err() );
+        assert!(countsig.add_bitsig(&bitsig1a).is_ok());
+        assert!(countsig.add_bitsig(&bitsig1a).is_ok());
+        assert!(countsig.add_bitsig(&bitsig2).is_err());
         let countpop2 = countsig.clone();
-        assert!( countsig.merge(&countpop2).is_ok() );
-        assert!( verifiers::verify_unoptimized(&countsig) );
-        assert!( verifiers::verify_simple(&countsig) );
-        assert!( verifiers::verify_with_distinct_messages(&countsig,false) );
+        assert!(countsig.merge(&countpop2).is_ok());
+        assert!(verifiers::verify_unoptimized(&countsig));
+        assert!(verifiers::verify_simple(&countsig));
+        assert!(verifiers::verify_with_distinct_messages(&countsig, false));
         countsig.max_duplicates = 4;
-        assert!( countsig.merge(&countpop2).is_err() );
+        assert!(countsig.merge(&countpop2).is_err());
     }
 }

--- a/src/chaum_pedersen_signature.rs
+++ b/src/chaum_pedersen_signature.rs
@@ -1,15 +1,14 @@
-use ark_ec::{Group};
-use ark_ff::{PrimeField};
+use ark_ec::Group;
+use ark_ff::PrimeField;
 
-use digest::{Digest};
+use digest::Digest;
 
-
-use crate::{Message, SecretKeyVT};
+use crate::double::PublicKeyInSignatureGroup;
 use crate::engine::EngineBLS;
-use crate::serialize::SerializableToBytes;
-use crate::single::{Signature,};
-use crate::double::{PublicKeyInSignatureGroup, };
 use crate::schnorr_pop::SchnorrProof;
+use crate::serialize::SerializableToBytes;
+use crate::single::Signature;
+use crate::{Message, SecretKeyVT};
 
 pub type ChaumPedersenSignature<E> = (Signature<E>, SchnorrProof<E>);
 
@@ -18,80 +17,126 @@ pub trait ChaumPedersenSigner<E: EngineBLS, H: Digest> {
     /// The proof of possession generator is supposed to
     /// to produce a schnoor signature of the message using
     /// the secret key which it claim to possess.
-    fn generate_cp_signature(&mut self, message: Message) -> ChaumPedersenSignature<E>;
+    fn generate_cp_signature(&mut self, message: &Message) -> ChaumPedersenSignature<E>;
 
-    fn generate_witness_scaler(&self, message: Message) -> <<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField;
+    fn generate_witness_scaler(
+        &self,
+        message: &Message,
+    ) -> <<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField;
 
-    fn generate_dleq_proof(&mut self, message: Message, bls_signature: E::SignatureGroup) -> SchnorrProof<E>;
+    fn generate_dleq_proof(
+        &mut self,
+        message: &Message,
+        bls_signature: E::SignatureGroup,
+    ) -> SchnorrProof<E>;
 }
 
 /// This should be implemented by public key
-pub trait ChaumPedersenVerifier<E: EngineBLS, H: Digest> { 
-    fn verify_cp_signature(&self, message: Message, signature_proof: ChaumPedersenSignature<E>) -> bool;
+pub trait ChaumPedersenVerifier<E: EngineBLS, H: Digest> {
+    fn verify_cp_signature(
+        &self,
+        message: &Message,
+        signature_proof: ChaumPedersenSignature<E>,
+    ) -> bool;
 }
 
-impl<E: EngineBLS, H: Digest> ChaumPedersenSigner<E,H> for SecretKeyVT<E> {
-    fn generate_cp_signature(&mut self, message: Message) -> ChaumPedersenSignature<E> {
+impl<E: EngineBLS, H: Digest> ChaumPedersenSigner<E, H> for SecretKeyVT<E> {
+    fn generate_cp_signature(&mut self, message: &Message) -> ChaumPedersenSignature<E> {
         //First we generate a vanila BLS Signature;
         let bls_signature = SecretKeyVT::sign(self, message);
-        (bls_signature, <SecretKeyVT<E> as ChaumPedersenSigner<E, H>>::generate_dleq_proof(self, message, bls_signature.0))
+        (
+            bls_signature,
+            <SecretKeyVT<E> as ChaumPedersenSigner<E, H>>::generate_dleq_proof(
+                self,
+                message,
+                bls_signature.0,
+            ),
+        )
     }
 
     #[allow(non_snake_case)]
-    fn generate_dleq_proof(&mut self, message: Message, bls_signature: E::SignatureGroup) -> SchnorrProof<E> {
-        let mut k = <SecretKeyVT<E> as ChaumPedersenSigner<E, H>>::generate_witness_scaler(self, message);
+    fn generate_dleq_proof(
+        &mut self,
+        message: &Message,
+        bls_signature: E::SignatureGroup,
+    ) -> SchnorrProof<E> {
+        let mut k =
+            <SecretKeyVT<E> as ChaumPedersenSigner<E, H>>::generate_witness_scaler(self, message);
 
         let signature_point = bls_signature;
-	let message_point = message.hash_to_signature_curve::<E>();
+        let message_point = message.hash_to_signature_curve::<E>();
 
         let A_point = <<E as EngineBLS>::SignatureGroup as Group>::generator() * k;
         let B_point = message_point * k;
-        
+
         let A_point_as_bytes = E::signature_point_to_byte(&A_point);
         let B_point_as_bytes = E::signature_point_to_byte(&B_point);
 
         let signature_point_as_bytes = E::signature_point_to_byte(&signature_point);
 
-        let random_scalar =  <H as Digest>::new().chain_update(A_point_as_bytes).chain_update(B_point_as_bytes).chain_update(signature_point_as_bytes).finalize();
+        let random_scalar = <H as Digest>::new()
+            .chain_update(A_point_as_bytes)
+            .chain_update(B_point_as_bytes)
+            .chain_update(signature_point_as_bytes)
+            .finalize();
 
-        let c = <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(&*random_scalar);
-        let s = k -  c* self.0;
+        let c = <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(
+            &*random_scalar,
+        );
+        let s = k - c * self.0;
 
         ::zeroize::Zeroize::zeroize(&mut k); //clear secret witness from memory
-        
+
         (c, s)
     }
 
-    fn generate_witness_scaler(&self, message: Message) -> <<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField {
+    fn generate_witness_scaler(
+        &self,
+        message: &Message,
+    ) -> <<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField {
         let secret_key_as_bytes = self.to_bytes();
-                
-        let mut scalar_bytes = <H as Digest>::new().chain_update(secret_key_as_bytes).chain_update(message.0).finalize();
-	    let random_scalar : &mut [u8] = scalar_bytes.as_mut_slice();
-        <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(&*random_scalar)
 
+        let mut scalar_bytes = <H as Digest>::new()
+            .chain_update(secret_key_as_bytes)
+            .chain_update(message.0)
+            .finalize();
+        let random_scalar: &mut [u8] = scalar_bytes.as_mut_slice();
+        <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(
+            &*random_scalar,
+        )
     }
-    
 }
 
 /// This should be implemented by public key
 #[allow(non_snake_case)]
-impl<E: EngineBLS, H: Digest>  ChaumPedersenVerifier<E, H> for PublicKeyInSignatureGroup<E> { 
-    fn verify_cp_signature(&self, message: Message, signature_proof: ChaumPedersenSignature<E>) -> bool {
-        let A_check_point = <<E as EngineBLS>::SignatureGroup as Group>::generator() * signature_proof.1.1 +
-            self.0 * signature_proof.1.0;
+impl<E: EngineBLS, H: Digest> ChaumPedersenVerifier<E, H> for PublicKeyInSignatureGroup<E> {
+    fn verify_cp_signature(
+        &self,
+        message: &Message,
+        signature_proof: ChaumPedersenSignature<E>,
+    ) -> bool {
+        let A_check_point = <<E as EngineBLS>::SignatureGroup as Group>::generator()
+            * signature_proof.1 .1
+            + self.0 * signature_proof.1 .0;
 
-        let B_check_point = message.hash_to_signature_curve::<E>() * signature_proof.1.1 +
-            signature_proof.0.0 * signature_proof.1.0;
+        let B_check_point = message.hash_to_signature_curve::<E>() * signature_proof.1 .1
+            + signature_proof.0 .0 * signature_proof.1 .0;
 
-	let A_point_as_bytes = E::signature_point_to_byte(&A_check_point);
+        let A_point_as_bytes = E::signature_point_to_byte(&A_check_point);
         let B_point_as_bytes = E::signature_point_to_byte(&B_check_point);
 
         let signature_point_as_bytes = signature_proof.0.to_bytes();
-        
-        let resulting_scalar =  <H as Digest>::new().chain_update(A_point_as_bytes).chain_update(B_point_as_bytes).chain_update(signature_point_as_bytes).finalize();
-        let c_check = <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(&*resulting_scalar);
 
-        c_check == signature_proof.1.0
+        let resulting_scalar = <H as Digest>::new()
+            .chain_update(A_point_as_bytes)
+            .chain_update(B_point_as_bytes)
+            .chain_update(signature_point_as_bytes)
+            .finalize();
+        let c_check =
+            <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(
+                &*resulting_scalar,
+            );
 
+        c_check == signature_proof.1 .0
     }
 }

--- a/src/chaum_pedersen_signature.rs
+++ b/src/chaum_pedersen_signature.rs
@@ -74,7 +74,9 @@ impl<E: EngineBLS, H: Digest> ChaumPedersenSigner<E, H> for SecretKeyVT<E> {
 
         let signature_point_as_bytes = E::signature_point_to_byte(&signature_point);
         let message_point_as_bytes = E::signature_point_to_byte(&message_point);
-        let public_key_in_signature_group_as_bytes = E::signature_point_to_byte(&DoublePublicKeyScheme::<E>::into_public_key_in_signature_group(self).0);
+        let public_key_in_signature_group_as_bytes = E::signature_point_to_byte(
+            &DoublePublicKeyScheme::<E>::into_public_key_in_signature_group(self).0,
+        );
 
         let random_scalar = <H as Digest>::new()
             .chain_update(message_point_as_bytes)
@@ -130,7 +132,8 @@ impl<E: EngineBLS, H: Digest> ChaumPedersenVerifier<E, H> for PublicKeyInSignatu
         let B_point_as_bytes = E::signature_point_to_byte(&B_check_point);
 
         let signature_point_as_bytes = signature_proof.0.to_bytes();
-        let message_point_as_bytes = E::signature_point_to_byte(&message.hash_to_signature_curve::<E>());
+        let message_point_as_bytes =
+            E::signature_point_to_byte(&message.hash_to_signature_curve::<E>());
         let public_key_in_signature_group_as_bytes = E::signature_point_to_byte(&self.0);
 
         let resulting_scalar = <H as Digest>::new()

--- a/src/delinear.rs
+++ b/src/delinear.rs
@@ -3,29 +3,32 @@
 //! We handle delinearized flavors of aggregate BLS signatures here,
 //! meaning we multiply signatures by an exponent that seems random
 //! relative to the signers public key.  In this, we support both
-//! batching with explicit randomness, and delinearization in which 
+//! batching with explicit randomness, and delinearization in which
 //! we [treat the hash of all included public keys as a random oracle](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html)
-//! 
+//!
 //! We caution that delinerized aggregation leans towards slightly
 //! different abstractions than linear aggregation.  In this module,
 //! we select an approach that complements well our linear strategies,
 //! but if you need delinearized aggregation then you should consider
 //! adding a more finely tuned scheme.
 
+use ark_ec::CurveGroup;
+use ark_ff::BigInteger;
 use ark_ff::{PrimeField, Zero};
 use ark_serialize::CanonicalSerialize;
-use ark_ff::BigInteger;
-use ark_ec::CurveGroup;
 #[cfg(feature = "std")]
 use rand::thread_rng;
-use rand::{Rng};
-use sha3::{Shake128, digest::{Update, ExtendableOutput, XofReader}};
+use rand::Rng;
+use sha3::{
+    digest::{ExtendableOutput, Update, XofReader},
+    Shake128,
+};
 
 use std::collections::HashMap;
 
-use super::*;
 use super::single::SignedMessage;
 use super::verifiers::verify_with_distinct_messages;
+use super::*;
 
 /// Delinearized batched and aggregated BLS signatures.
 ///
@@ -33,14 +36,14 @@ use super::verifiers::verify_with_distinct_messages;
 /// optimizations possible.  We believe it fits well when messages
 /// are often repeated but signers are rarely repeated.
 ///
-/// We should create another type for when repeated signers are 
+/// We should create another type for when repeated signers are
 /// expected, likely by keying the hash map on the pubkic key.
 /// In practice though, if signers are often repeated then you should
 /// should consider a proof-of-possession scheme, which requiees all
 /// signers register in advance.
 pub struct Delinearized<E: EngineBLS> {
     key: Shake128,
-    messages_n_publickeys: HashMap<Message,PublicKey<E>>,
+    messages_n_publickeys: HashMap<Message, PublicKey<E>>,
     signature: Signature<E>,
 }
 
@@ -54,21 +57,23 @@ impl<E: EngineBLS> Clone for Delinearized<E> {
     }
 }
 
-impl<'a,E: EngineBLS> Signed for &'a Delinearized<E> {
+impl<'a, E: EngineBLS> Signed for &'a Delinearized<E> {
     type E = E;
 
     type M = &'a Message;
     type PKG = &'a PublicKey<Self::E>;
-    type PKnM = ::std::collections::hash_map::Iter<'a,Message,PublicKey<E>>;
+    type PKnM = ::std::collections::hash_map::Iter<'a, Message, PublicKey<E>>;
 
     fn messages_and_publickeys(self) -> Self::PKnM {
         self.messages_n_publickeys.iter()
     }
 
-    fn signature(&self) -> Signature<E> { self.signature }
+    fn signature(&self) -> Signature<E> {
+        self.signature
+    }
 
     fn verify(self) -> bool {
-        verify_with_distinct_messages(self,true)
+        verify_with_distinct_messages(self, true)
     }
 }
 
@@ -106,12 +111,14 @@ impl<E: EngineBLS> Delinearized<E> {
     pub fn mask(&self, publickey: &PublicKey<E>) -> E::Scalar {
         let mut t = self.key.clone();
         let pk_affine = publickey.0.into_affine();
-        let mut pk_uncompressed = vec![0;  pk_affine.uncompressed_size()];        
-        pk_affine.serialize_uncompressed(&mut pk_uncompressed[..]).unwrap();
+        let mut pk_uncompressed = vec![0; pk_affine.uncompressed_size()];
+        pk_affine
+            .serialize_uncompressed(&mut pk_uncompressed[..])
+            .unwrap();
         t.update(&pk_uncompressed);
         let mut b = [0u8; 16];
         t.finalize_xof().read(&mut b[..]);
-        let (x,y) = array_refs!(&b,8,8);
+        let (x, y) = array_refs!(&b, 8, 8);
         let mut x: <E::Scalar as PrimeField>::BigInt = u64::from_le_bytes(*x).into();
         let y: <E::Scalar as PrimeField>::BigInt = u64::from_le_bytes(*y).into();
         x.muln(64);
@@ -132,7 +139,11 @@ impl<E: EngineBLS> Delinearized<E> {
     ///
     /// Useful for constructing an aggregate signature, but we
     /// recommend instead using a custom types like `BitPoPSignedMessage`.
-    pub fn add_message_n_publickey(&mut self, message: &Message, mut publickey: PublicKey<E>) -> E::Scalar {
+    pub fn add_message_n_publickey(
+        &mut self,
+        message: &Message,
+        mut publickey: PublicKey<E>,
+    ) -> E::Scalar {
         let mask = self.mask(&publickey);
         // We must use projective corrdinates here, dispite converting to
         // affine just above, because only `CurveGroup::mul_assign`
@@ -143,17 +154,17 @@ impl<E: EngineBLS> Delinearized<E> {
         // Or even expose the `AffineRepr::mul_bits` method.
         // TODO: Is using affine here actually faster?
         publickey.0 *= mask;
-        self.messages_n_publickeys.entry(*message)
+        self.messages_n_publickeys
+            .entry(message.clone())
             .and_modify(|pk0| pk0.0 += publickey.0)
             .or_insert(publickey);
         mask
     }
 
     /// Aggregage BLS signatures from singletons using delinearization
-    pub fn add(&mut self, signed: &SignedMessage<E>)
-    {
+    pub fn add(&mut self, signed: &SignedMessage<E>) {
         let mut signature = signed.signature;
-        let mask = self.add_message_n_publickey(&signed.message,signed.publickey);
+        let mask = self.add_message_n_publickey(&signed.message, signed.publickey);
         signature.0 *= mask;
         self.add_delinearized_signature(&signature);
     }
@@ -178,17 +189,16 @@ impl<E: EngineBLS> Delinearized<E> {
     // TODO: Feed into disjoint message aggregation.
     pub fn merge(&mut self, other: &Delinearized<E>) {
         // if ! self.agreement(other) { return Err(()); }
-        for (message,publickey) in other.messages_n_publickeys.iter() {
-            self.messages_n_publickeys.entry(*message)
-                .and_modify(|pk0| pk0.0 += publickey.0 )
+        for (message, publickey) in other.messages_n_publickeys.iter() {
+            self.messages_n_publickeys
+                .entry(message.clone())
+                .and_modify(|pk0| pk0.0 += publickey.0)
                 .or_insert(*publickey);
         }
         self.signature.0 += other.signature.0;
         // Ok(())
     }
 }
-
-
 
 /*
 type PublicKeyUncompressed<E> = <<<E as EngineBLS>::$group as ProjectiveCurve>::Affine as AffineRepr>::Compressed;
@@ -201,35 +211,37 @@ pub struct DelinearizedRepeatedSigners<E: EngineBLS> {
 }
 */
 
-#[cfg(all(test, feature="std"))]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
 
     #[test]
     fn delinearized() {
-        let msg1 = Message::new(b"ctx",b"some message");
+        let msg1 = Message::new(b"ctx", b"some message");
 
         let k = |_| Keypair::<ZBLS>::generate(thread_rng());
         let mut keypairs = (0..4).into_iter().map(k).collect::<Vec<_>>();
         let dup = keypairs[3].clone();
         keypairs.push(dup);
-        let sigs1 = keypairs.iter_mut().map(|k| k.signed_message(msg1)).collect::<Vec<_>>();
+        let sigs1 = keypairs
+            .iter_mut()
+            .map(|k| k.signed_message(&msg1))
+            .collect::<Vec<_>>();
 
         let mut dl = Delinearized::<ZBLS>::new_batched();
         for sig in sigs1.iter() {
             dl.add(sig);
-            assert!( dl.verify() );  // verifiers::verify_with_distinct_messages(&dms,true)
+            assert!(dl.verify()); // verifiers::verify_with_distinct_messages(&dms,true)
         }
-        assert!( verifiers::verify_unoptimized(&dl) );
-        assert!( verifiers::verify_simple(&dl) );
-        assert!( verifiers::verify_with_distinct_messages(&dl,false) );
+        assert!(verifiers::verify_unoptimized(&dl));
+        assert!(verifiers::verify_simple(&dl));
+        assert!(verifiers::verify_with_distinct_messages(&dl, false));
         // assert!( verifiers::verify_with_gaussian_elimination(&dl) );
 
-        assert!( dl.agreement(&dl) );
+        assert!(dl.agreement(&dl));
         let dl_too = dl.clone();
         dl.merge(&dl_too);
-        assert!( dl.verify() );
+        assert!(dl.verify());
         // TODO: more more
     }
 }
-

--- a/src/distinct.rs
+++ b/src/distinct.rs
@@ -13,21 +13,19 @@
 //! requirement to enforce distinct messages.
 //!
 //! We also note that most signature schemes permit support extremely
-//! efficent signer side batching, which normally out performs BLS. 
+//! efficent signer side batching, which normally out performs BLS.
 //! It's ocasioanlly worth asking if signers can be trusted to such
 //! collected signatures.  See also:
 //! - RSA:  https://eprint.iacr.org/2018/082.pdf
 //! - Boneh-Boyen:  https://crypto.stanford.edu/~dabo/papers/bbsigs.pdf
 //!     http://sci-gems.math.bas.bg:8080/jspui/bitstream/10525/1569/1/sjc096-vol3-num3-2009.pdf
 
-
+use ark_ff::Zero;
 use std::collections::HashMap;
-use ark_ff::{Zero};
 
-use super::*;
 use super::single::SignedMessage;
 use super::verifiers::verify_with_distinct_messages;
-
+use super::*;
 
 /// Error tyoe for non-distinct messages found during distinct
 /// message aggregation.
@@ -47,12 +45,12 @@ impl ::std::fmt::Display for AttackViaDuplicateMessages {
 
 impl ::std::error::Error for AttackViaDuplicateMessages {
     fn description(&self) -> &str {
-        "Attempted to aggregate duplicate messages." 
+        "Attempted to aggregate duplicate messages."
     }
 }
 
 /// Distinct messages with attached BLS signature
-/// 
+///
 /// We can aggregate BLS signatures on distinct messages without
 /// additional assuptions or delinearization.  In this variant, there
 /// is obviously no aggregation on the signature curve, so verification
@@ -74,22 +72,24 @@ impl ::std::error::Error for AttackViaDuplicateMessages {
 /// seperately, and reconstruct this type using its `add_*` methods.
 #[derive(Clone)]
 pub struct DistinctMessages<E: EngineBLS> {
-    messages_n_publickeys: HashMap<Message,PublicKey<E>>,
+    messages_n_publickeys: HashMap<Message, PublicKey<E>>,
     signature: Signature<E>,
 }
 
-impl<'a,E: EngineBLS> Signed for &'a DistinctMessages<E> {
+impl<'a, E: EngineBLS> Signed for &'a DistinctMessages<E> {
     type E = E;
 
     type M = &'a Message;
     type PKG = &'a PublicKey<Self::E>;
-    type PKnM = ::std::collections::hash_map::Iter<'a,Message,PublicKey<E>>;
+    type PKnM = ::std::collections::hash_map::Iter<'a, Message, PublicKey<E>>;
 
     fn messages_and_publickeys(self) -> Self::PKnM {
         self.messages_n_publickeys.iter()
     }
 
-    fn signature(&self) -> Signature<E> { self.signature }
+    fn signature(&self) -> Signature<E> {
+        self.signature
+    }
 
     fn verify(self) -> bool {
         verify_with_distinct_messages(self, false)
@@ -111,7 +111,6 @@ impl<E: EngineBLS> DistinctMessages<E> {
             signature: Signature(E::SignatureGroup::zero()),
         }
     }
-    
 
     /// Add only a `Signature<E>` to our internal signature.
     ///
@@ -126,10 +125,12 @@ impl<E: EngineBLS> DistinctMessages<E> {
     ///
     /// We require that duplicate message halt verification by consuming
     /// self by vaule and return it only if no duplicates occur.
-    pub fn add_message_n_publickey(mut self, message: Message, publickey: PublicKey<E>)
-     -> DistinctMessagesResult<E>
-     {
-        if let Some(_old_publickey) = self.messages_n_publickeys.insert(message,publickey) {
+    pub fn add_message_n_publickey(
+        mut self,
+        message: Message,
+        publickey: PublicKey<E>,
+    ) -> DistinctMessagesResult<E> {
+        if let Some(_old_publickey) = self.messages_n_publickeys.insert(message, publickey) {
             // We need not recover from this error because the hash map gets erased.
             // self.messages_n_publickeys.insert(signed.message,old_publickey);
             return Err(AttackViaDuplicateMessages);
@@ -141,9 +142,8 @@ impl<E: EngineBLS> DistinctMessages<E> {
     ///
     /// We require that duplicate message halt verification by consuming
     /// self by vaule and return it only if no duplicates occur.
-    pub fn add(self, signed: &SignedMessage<E>) -> DistinctMessagesResult<E>
-    {
-        let mut me = self.add_message_n_publickey(signed.message,signed.publickey) ?;
+    pub fn add(self, signed: &SignedMessage<E>) -> DistinctMessagesResult<E> {
+        let mut me = self.add_message_n_publickey(signed.message.clone(), signed.publickey)?;
         me.add_signature(&signed.signature);
         Ok(me)
     }
@@ -152,8 +152,7 @@ impl<E: EngineBLS> DistinctMessages<E> {
     ///
     /// We require that duplicate message halt verification by consuming
     /// self by vaule and return it only if no duplicates occur.
-    pub fn merge(mut self, signed: &DistinctMessages<E>) -> DistinctMessagesResult<E>
-    {
+    pub fn merge(mut self, signed: &DistinctMessages<E>) -> DistinctMessagesResult<E> {
         // We need not detect duplicates early for recovery because
         // duplicates cause our hashmap to be freed anyways.
         // for (m,_pk) in signed.messages_n_publickeys.iter() {
@@ -161,9 +160,9 @@ impl<E: EngineBLS> DistinctMessages<E> {
         //      return Err(AttackViaDuplicateMessages);
         //     }
         // }
-        for (m,pk) in signed.messages_n_publickeys.iter() {
+        for (m, pk) in signed.messages_n_publickeys.iter() {
             // assert!(self.messages_n_publickeys.insert(*m,*pk).is_none());
-            if self.messages_n_publickeys.insert(*m,*pk).is_some() {
+            if self.messages_n_publickeys.insert(m.clone(), *pk).is_some() {
                 return Err(AttackViaDuplicateMessages);
             }
         }
@@ -172,7 +171,7 @@ impl<E: EngineBLS> DistinctMessages<E> {
     }
 }
 
-pub type DistinctMessagesResult<E> = Result<DistinctMessages<E>,AttackViaDuplicateMessages>;
+pub type DistinctMessagesResult<E> = Result<DistinctMessages<E>, AttackViaDuplicateMessages>;
 
 /*
 TODO: Adopt .collect::<DistinctMessagesResult<E>>() via FromIterator
@@ -186,45 +185,62 @@ impl<'a,E: EngineBLS> FromIterator<&'a SignedMessage<E>> for DistinctMessagesRes
 }
 */
 
-
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use rand::{thread_rng};  // Rng
+    use rand::thread_rng; // Rng
 
     use super::*;
 
     #[test]
     fn distinct_messages() {
-        let msgs = [ Message::new(b"ctx",b"Message1"), Message::new(b"ctx",b"Message1"), Message::new(b"ctx",b"Message2"), Message::new(b"ctx",b"Message3"), Message::new(b"ctx",b"Message4") ];
+        let msgs = [
+            Message::new(b"ctx", b"Message1"),
+            Message::new(b"ctx", b"Message1"),
+            Message::new(b"ctx", b"Message2"),
+            Message::new(b"ctx", b"Message3"),
+            Message::new(b"ctx", b"Message4"),
+        ];
 
         let k = |_| Keypair::<ZBLS>::generate(thread_rng());
         let mut keypairs = (0..4).into_iter().map(k).collect::<Vec<_>>();
         let dup = keypairs[3].clone();
         keypairs.push(dup);
 
-        let sigs = msgs.iter().zip(keypairs.iter_mut()).map(|(m,k)| k.signed_message(*m)).collect::<Vec<_>>();  
+        let sigs = msgs
+            .iter()
+            .zip(keypairs.iter_mut())
+            .map(|(m, k)| k.signed_message(m))
+            .collect::<Vec<_>>();
 
         let dm_new = || DistinctMessages::<ZBLS>::new();
-        fn dm_add(dm: DistinctMessages<ZBLS>, sig: &SignedMessage<ZBLS>)
-         -> Result<DistinctMessages<ZBLS>,AttackViaDuplicateMessages>
-            { dm.add(sig) }
+        fn dm_add(
+            dm: DistinctMessages<ZBLS>,
+            sig: &SignedMessage<ZBLS>,
+        ) -> Result<DistinctMessages<ZBLS>, AttackViaDuplicateMessages> {
+            dm.add(sig)
+        }
 
         let mut dms = sigs.iter().skip(1).try_fold(dm_new(), dm_add).unwrap();
-        assert!( dms.messages_and_publickeys().len() == 4 );
+        assert!(dms.messages_and_publickeys().len() == 4);
         let dms0 = sigs.iter().skip(1).try_fold(dm_new(), dm_add).unwrap();
-        assert!( dms0.merge(&dms).is_err() );
-        assert!( sigs.iter().try_fold(dm_new(), dm_add).is_err() );
-        assert!( dms.verify() ); // verifiers::verify_with_distinct_messages(&dms,false)
-        assert!( verifiers::verify_unoptimized(&dms) );
-        assert!( verifiers::verify_simple(&dms) );
-        assert!( verifiers::verify_with_distinct_messages(&dms,true) );
+        assert!(dms0.merge(&dms).is_err());
+        assert!(sigs.iter().try_fold(dm_new(), dm_add).is_err());
+        assert!(dms.verify()); // verifiers::verify_with_distinct_messages(&dms,false)
+        assert!(verifiers::verify_unoptimized(&dms));
+        assert!(verifiers::verify_simple(&dms));
+        assert!(verifiers::verify_with_distinct_messages(&dms, true));
         // assert!( verifiers::verify_with_gaussian_elimination(&dms) );
 
-        let dms1 = sigs.iter().skip(1).take(2).try_fold(dm_new(), dm_add).unwrap();
+        let dms1 = sigs
+            .iter()
+            .skip(1)
+            .take(2)
+            .try_fold(dm_new(), dm_add)
+            .unwrap();
         let dms2 = sigs.iter().skip(3).try_fold(dm_new(), dm_add).unwrap();
-        assert!( dms1.merge(&dms2).unwrap().signature == dms.signature );
+        assert!(dms1.merge(&dms2).unwrap().signature == dms.signature);
 
         *(dms.messages_n_publickeys.get_mut(&msgs[1]).unwrap()) = keypairs[0].public.clone();
-        assert!( ! dms.verify() , "Verification by an incorrect signer passed");
+        assert!(!dms.verify(), "Verification by an incorrect signer passed");
     }
 }

--- a/src/double.rs
+++ b/src/double.rs
@@ -6,9 +6,9 @@
 //!
 //! The scheme proposes for the public key be represented by doube points,
 //! both in G1 and G2 and aggregate keys in G1.
-//! 
+//!
 //! It also proposes that each individual BLS signature accompany a DLEQ proof
-//! for faster verification 
+//! for faster verification
 
 use alloc::vec::Vec;
 use core::iter::once;

--- a/src/double.rs
+++ b/src/double.rs
@@ -1,62 +1,71 @@
 //! ## Unaggreagated BLS signatures with double public key and DLEQ proof
 //!
 
+use alloc::vec::Vec;
 use core::iter::once;
-use alloc::{vec::Vec};
 
-use ark_ec::{CurveGroup,AffineRepr,};
+use ark_ec::{AffineRepr, CurveGroup};
 
-use ark_serialize::{CanonicalSerialize, CanonicalDeserialize};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use sha2::Sha256;
 
-use crate::serialize::SerializableToBytes;
-use crate::{broken_derives};
-use crate::single::{SecretKeyVT,KeypairVT,PublicKey,Keypair, Signature};
-use crate::schnorr_pop::SchnorrProof;
+use crate::broken_derives;
 use crate::chaum_pedersen_signature::{ChaumPedersenSigner, ChaumPedersenVerifier};
+use crate::schnorr_pop::SchnorrProof;
+use crate::serialize::SerializableToBytes;
+use crate::single::{Keypair, KeypairVT, PublicKey, SecretKeyVT, Signature};
 use crate::{EngineBLS, Message, Signed};
 
 /// Wrapper for a point in the signature group which is supposed to
 /// the same logarithm as the public key in the public key group
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct PublicKeyInSignatureGroup<E: EngineBLS>(pub E::SignatureGroup);
-broken_derives!(PublicKeyInSignatureGroup);  // Actually the derive works for this one, not sure why.
+broken_derives!(PublicKeyInSignatureGroup); // Actually the derive works for this one, not sure why.
 
 /// BLS Public Key with sub keys in both groups.
 #[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct DoublePublicKey<E: EngineBLS>(pub E::SignatureGroup, pub E::PublicKeyGroup);
 
-impl <E: EngineBLS>  DoublePublicKey<E>  {
-    pub fn verify(&self, message: Message, signature: &DoubleSignature<E>) -> bool {
-        signature.verify(message,self)
+impl<E: EngineBLS> DoublePublicKey<E> {
+    pub fn verify(&self, message: &Message, signature: &DoubleSignature<E>) -> bool {
+        signature.verify(message, self)
     }
 }
 
 /// Serialization for DoublePublickey
-impl <E: EngineBLS> SerializableToBytes for DoublePublicKey<E>  {const SERIALIZED_BYTES_SIZE : usize  = E::SIGNATURE_SERIALIZED_SIZE+ E::PUBLICKEY_SERIALIZED_SIZE;}
+impl<E: EngineBLS> SerializableToBytes for DoublePublicKey<E> {
+    const SERIALIZED_BYTES_SIZE: usize =
+        E::SIGNATURE_SERIALIZED_SIZE + E::PUBLICKEY_SERIALIZED_SIZE;
+}
 
 pub trait DoublePublicKeyScheme<E: EngineBLS> {
-   fn into_public_key_in_signature_group(&self) -> PublicKeyInSignatureGroup<E>;
+    fn into_public_key_in_signature_group(&self) -> PublicKeyInSignatureGroup<E>;
 
     /// Return a double public object containing public keys both in G1 and G2
     fn into_double_public_key(&self) -> DoublePublicKey<E>;
-    fn sign(&mut self, message: Message) -> DoubleSignature<E>;
+    fn sign(&mut self, message: &Message) -> DoubleSignature<E>;
 }
 
 impl<E: EngineBLS> DoublePublicKeyScheme<E> for SecretKeyVT<E> {
     fn into_public_key_in_signature_group(&self) -> PublicKeyInSignatureGroup<E> {
-        PublicKeyInSignatureGroup( <E::SignatureGroup as CurveGroup>::Affine::generator().into_group()*self.0)       
+        PublicKeyInSignatureGroup(
+            <E::SignatureGroup as CurveGroup>::Affine::generator().into_group() * self.0,
+        )
     }
-    
+
     fn into_double_public_key(&self) -> DoublePublicKey<E> {
-	DoublePublicKey(self.into_public_key_in_signature_group().0, self.into_public().0)
+        DoublePublicKey(
+            self.into_public_key_in_signature_group().0,
+            self.into_public().0,
+        )
     }
 
     /// Sign a message using a Seedabale RNG created from a seed derived from the message and key
-    fn sign(&mut self, message: Message) -> DoubleSignature<E> {
-	let chaum_pedersen_signature = ChaumPedersenSigner::<E, Sha256>::generate_cp_signature(self, message);
-	DoubleSignature(chaum_pedersen_signature.0.0, chaum_pedersen_signature.1)
+    fn sign(&mut self, message: &Message) -> DoubleSignature<E> {
+        let chaum_pedersen_signature =
+            ChaumPedersenSigner::<E, Sha256>::generate_cp_signature(self, &message);
+        DoubleSignature(chaum_pedersen_signature.0 .0, chaum_pedersen_signature.1)
     }
 }
 
@@ -66,14 +75,13 @@ impl<E: EngineBLS> DoublePublicKeyScheme<E> for KeypairVT<E> {
     }
 
     fn into_double_public_key(&self) -> DoublePublicKey<E> {
-	self.secret.into_double_public_key()
+        self.secret.into_double_public_key()
     }
 
     /// Sign a message using a Seedabale RNG created from a seed derived from the message and key
-    fn sign(&mut self, message: Message) -> DoubleSignature<E> {
-	DoublePublicKeyScheme::sign(&mut self.secret, message)
+    fn sign(&mut self, message: &Message) -> DoubleSignature<E> {
+        DoublePublicKeyScheme::sign(&mut self.secret, message)
     }
-
 }
 
 impl<E: EngineBLS> DoublePublicKeyScheme<E> for Keypair<E> {
@@ -82,14 +90,13 @@ impl<E: EngineBLS> DoublePublicKeyScheme<E> for Keypair<E> {
     }
 
     fn into_double_public_key(&self) -> DoublePublicKey<E> {
-	self.into_vartime().into_double_public_key()
+        self.into_vartime().into_double_public_key()
     }
 
     /// Sign a message using a Seedabale RNG created from a seed derived from the message and key
-    fn sign(&mut self, message: Message) -> DoubleSignature<E> {
-	DoublePublicKeyScheme::sign(&mut self.into_vartime(), message)
+    fn sign(&mut self, message: &Message) -> DoubleSignature<E> {
+        DoublePublicKeyScheme::sign(&mut self.into_vartime(), message)
     }
-    
 }
 
 /// Detached BLS Signature containing DLEQ
@@ -97,17 +104,21 @@ impl<E: EngineBLS> DoublePublicKeyScheme<E> for Keypair<E> {
 pub struct DoubleSignature<E: EngineBLS>(pub E::SignatureGroup, SchnorrProof<E>);
 
 impl<E: EngineBLS> DoubleSignature<E> {
-    //const DESCRIPTION : &'static str = "A BLS signature"; 
+    //const DESCRIPTION : &'static str = "A BLS signature";
 
     /// Verify a single BLS signature using DLEQ proof
-    pub fn verify(&self, message: Message, publickey: &DoublePublicKey<E>) -> bool {
-	<PublicKeyInSignatureGroup<E> as ChaumPedersenVerifier<E, Sha256>>::verify_cp_signature(&PublicKeyInSignatureGroup(publickey.0), message, (Signature(self.0),self.1))
+    pub fn verify(&self, message: &Message, publickey: &DoublePublicKey<E>) -> bool {
+        <PublicKeyInSignatureGroup<E> as ChaumPedersenVerifier<E, Sha256>>::verify_cp_signature(
+            &PublicKeyInSignatureGroup(publickey.0),
+            &message,
+            (Signature(self.0), self.1),
+        )
     }
 }
 
 /// Message with attached BLS signature
-/// 
-/// 
+///
+///
 #[derive(Debug, Clone)]
 pub struct DoubleSignedMessage<E: EngineBLS> {
     pub message: Message,
@@ -115,16 +126,16 @@ pub struct DoubleSignedMessage<E: EngineBLS> {
     pub signature: DoubleSignature<E>,
 }
 
-impl<E: EngineBLS>  PartialEq<Self> for DoubleSignedMessage<E> {
+impl<E: EngineBLS> PartialEq<Self> for DoubleSignedMessage<E> {
     fn eq(&self, other: &Self) -> bool {
         self.message.eq(&other.message)
-        && self.publickey.0.eq(&other.publickey.0)
-        && self.publickey.1.eq(&other.publickey.1)
-        && self.signature.0.eq(&other.signature.0)
+            && self.publickey.0.eq(&other.publickey.0)
+            && self.publickey.1.eq(&other.publickey.1)
+            && self.signature.0.eq(&other.signature.0)
     }
 }
 
-impl<'a,E: EngineBLS> Signed for &'a DoubleSignedMessage<E> {
+impl<'a, E: EngineBLS> Signed for &'a DoubleSignedMessage<E> {
     type E = E;
 
     type M = Message;
@@ -133,114 +144,198 @@ impl<'a,E: EngineBLS> Signed for &'a DoubleSignedMessage<E> {
     type PKnM = ::core::iter::Once<(Message, PublicKey<E>)>;
 
     fn messages_and_publickeys(self) -> Self::PKnM {
-        once((self.message.clone(), PublicKey(self.publickey.1)))    // TODO:  Avoid clone
+        once((self.message.clone(), PublicKey(self.publickey.1))) // TODO:  Avoid clone
     }
 
-    fn signature(&self) -> Signature<E> { Signature(self.signature.0) }
+    fn signature(&self) -> Signature<E> {
+        Signature(self.signature.0)
+    }
 
     fn verify(self) -> bool {
-	//we chaum pederesen verification which is faster
-	ChaumPedersenVerifier::<E, Sha256>::verify_cp_signature(&PublicKeyInSignatureGroup::<E>(self.publickey.0), self.message, (Signature(self.signature.0), self.signature.1))
-	    
-    }    
+        //we chaum pederesen verification which is faster
+        ChaumPedersenVerifier::<E, Sha256>::verify_cp_signature(
+            &PublicKeyInSignatureGroup::<E>(self.publickey.0),
+            &self.message,
+            (Signature(self.signature.0), self.signature.1),
+        )
+    }
 }
 
 /// Serialization for DoublePublickey
-impl <E: EngineBLS> SerializableToBytes for DoubleSignature<E> {const SERIALIZED_BYTES_SIZE : usize = E::SIGNATURE_SERIALIZED_SIZE + 2 * E::SECRET_KEY_SIZE; }
+impl<E: EngineBLS> SerializableToBytes for DoubleSignature<E> {
+    const SERIALIZED_BYTES_SIZE: usize = E::SIGNATURE_SERIALIZED_SIZE + 2 * E::SECRET_KEY_SIZE;
+}
 
-#[cfg(all(test, feature="std"))]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use rand::thread_rng;
-    
+
     use super::*;
 
-    use ark_ec::pairing::Pairing as PairingEngine;
-    use ark_bls12_381::Bls12_381;
     use ark_bls12_377::Bls12_377;
+    use ark_bls12_381::Bls12_381;
     use ark_ec::bls12::Bls12Config;
     use ark_ec::hashing::curve_maps::wb::{WBConfig, WBMap};
-    use ark_ec::hashing::map_to_curve_hasher::{MapToCurve};
-    
-    use crate::{ProofOfPossessionGenerator, ProofOfPossessionVerifier};
-    use crate::chaum_pedersen_signature::{ChaumPedersenSigner, ChaumPedersenVerifier};
-    use crate::{EngineBLS, UsualBLS, TinyBLS, Message};
+    use ark_ec::hashing::map_to_curve_hasher::MapToCurve;
+    use ark_ec::pairing::Pairing as PairingEngine;
 
+    use crate::{EngineBLS, Message, TinyBLS};
 
-    fn double_public_serialization_test<EB: EngineBLS<Engine = E>, E: PairingEngine, P: Bls12Config>(x: DoubleSignedMessage<EB>) -> DoubleSignedMessage<EB> where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2> 
+    fn double_public_serialization_test<
+        EB: EngineBLS<Engine = E>,
+        E: PairingEngine,
+        P: Bls12Config,
+    >(
+        x: DoubleSignedMessage<EB>,
+    ) -> DoubleSignedMessage<EB>
+    where
+        <P as Bls12Config>::G2Config: WBConfig,
+        WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2>,
     {
-        let DoubleSignedMessage { message, publickey, signature } = x;
+        let DoubleSignedMessage {
+            message,
+            publickey,
+            signature,
+        } = x;
 
         let publickey = DoublePublicKey::<EB>::from_bytes(&publickey.to_bytes()).unwrap();
         let signature = DoubleSignature::<EB>::from_bytes(&signature.to_bytes()).unwrap();
-        
-        DoubleSignedMessage { message, publickey, signature }
-        
+
+        DoubleSignedMessage {
+            message,
+            publickey,
+            signature,
+        }
     }
 
-    fn test_single_bls_message_double_signature_scheme<EB: EngineBLS<Engine = E, >, E: PairingEngine, P: Bls12Config>() where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2>  {
+    fn test_single_bls_message_double_signature_scheme<
+        EB: EngineBLS<Engine = E>,
+        E: PairingEngine,
+        P: Bls12Config,
+    >()
+    where
+        <P as Bls12Config>::G2Config: WBConfig,
+        WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2>,
+    {
+        let good = Message::new(b"ctx", b"test message");
 
-        let good = Message::new(b"ctx",b"test message");
+        let mut keypair = Keypair::<EB>::generate(thread_rng());
+        let public_key = DoublePublicKeyScheme::into_double_public_key(&mut keypair);
+        let good_sig = DoublePublicKeyScheme::sign(&mut keypair, &good);
 
-        let mut keypair  = Keypair::<EB>::generate(thread_rng());
-	let mut public_key = DoublePublicKeyScheme::into_double_public_key(&mut keypair);
-        let good_sig = DoublePublicKeyScheme::sign(&mut keypair, good);
+        assert!(
+            public_key.verify(&good, &good_sig),
+            "Verification of a valid signature failed!"
+        );
 
-        assert!(public_key.verify(good, &good_sig),
-                "Verification of a valid signature failed!");
+        let bad = Message::new(b"ctx", b"wrong message");
+        let bad_sig = DoublePublicKeyScheme::sign(&mut keypair, &bad);
 
-        let bad = Message::new(b"ctx",b"wrong message");
-	let bad_sig =  DoublePublicKeyScheme::sign(&mut keypair, bad);
+        assert!(bad_sig.verify(
+            &bad,
+            &DoublePublicKeyScheme::into_double_public_key(&keypair)
+        ));
 
-        assert!( bad_sig.verify(bad, &DoublePublicKeyScheme::into_double_public_key(&keypair) ));	
-	
-	assert!(good != bad, "good == bad");
-	assert!(good_sig.0 != bad_sig.0, "good sig == bad sig");
-	
-        assert!(!bad_sig.verify(good, &DoublePublicKeyScheme::into_double_public_key(&keypair)),
-                "Verification of a signature on a different message passed!");
-        assert!(!good_sig.verify(bad, &DoublePublicKeyScheme::into_double_public_key(&keypair)),
-                "Verification of a signature on a different message passed!");
+        assert!(good != bad, "good == bad");
+        assert!(good_sig.0 != bad_sig.0, "good sig == bad sig");
+
+        assert!(
+            !bad_sig.verify(
+                &good,
+                &DoublePublicKeyScheme::into_double_public_key(&keypair)
+            ),
+            "Verification of a signature on a different message passed!"
+        );
+        assert!(
+            !good_sig.verify(
+                &bad,
+                &DoublePublicKeyScheme::into_double_public_key(&keypair)
+            ),
+            "Verification of a signature on a different message passed!"
+        );
     }
 
     #[test]
     fn test_double_public_key_double_signature_serialization_for_bls12_377() {
-	let mut keypair  = Keypair::<TinyBLS<Bls12_377, ark_bls12_377::Config>>::generate(thread_rng());
-	let message = Message::new(b"ctx",b"test message");
-        let good_sig0 = DoublePublicKeyScheme::sign(&mut keypair, message);
+        let mut keypair =
+            Keypair::<TinyBLS<Bls12_377, ark_bls12_377::Config>>::generate(thread_rng());
+        let message = Message::new(b"ctx", b"test message");
+        let good_sig0 = DoublePublicKeyScheme::sign(&mut keypair, &message);
 
-	let signed_message = DoubleSignedMessage { message: message, publickey: DoublePublicKey(keypair.into_public_key_in_signature_group().0, keypair.public.0), signature: good_sig0};
+        let signed_message = DoubleSignedMessage {
+            message: message,
+            publickey: DoublePublicKey(
+                keypair.into_public_key_in_signature_group().0,
+                keypair.public.0,
+            ),
+            signature: good_sig0,
+        };
 
-	assert!(signed_message.verify(), "valid double signed message should verify");
+        assert!(
+            signed_message.verify(),
+            "valid double signed message should verify"
+        );
 
-	let deserialized_signed_message = double_public_serialization_test::<TinyBLS<Bls12_377, ark_bls12_377::Config>, Bls12_377, ark_bls12_377::Config>(signed_message);
+        let deserialized_signed_message = double_public_serialization_test::<
+            TinyBLS<Bls12_377, ark_bls12_377::Config>,
+            Bls12_377,
+            ark_bls12_377::Config,
+        >(signed_message);
 
-	assert!(deserialized_signed_message.verify(), "deserialized valid double signed message should verify");
-
+        assert!(
+            deserialized_signed_message.verify(),
+            "deserialized valid double signed message should verify"
+        );
     }
 
     #[test]
     fn test_double_public_key_double_signature_serialization_for_bls12_381() {
-	let mut keypair  = Keypair::<TinyBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-	let message = Message::new(b"ctx",b"test message");
-        let good_sig0 = DoublePublicKeyScheme::sign(&mut keypair, message);
+        let mut keypair =
+            Keypair::<TinyBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let message = Message::new(b"ctx", b"test message");
+        let good_sig0 = DoublePublicKeyScheme::sign(&mut keypair, &message);
 
-	let signed_message = DoubleSignedMessage { message: message, publickey: DoublePublicKey(keypair.into_public_key_in_signature_group().0, keypair.public.0), signature: good_sig0};
+        let signed_message = DoubleSignedMessage {
+            message: message,
+            publickey: DoublePublicKey(
+                keypair.into_public_key_in_signature_group().0,
+                keypair.public.0,
+            ),
+            signature: good_sig0,
+        };
 
-	assert!(signed_message.verify(), "valid double signed message should verify");
+        assert!(
+            signed_message.verify(),
+            "valid double signed message should verify"
+        );
 
-	let deserialized_signed_message = double_public_serialization_test::<TinyBLS<Bls12_381, ark_bls12_381::Config>, Bls12_381, ark_bls12_381::Config>(signed_message);
+        let deserialized_signed_message = double_public_serialization_test::<
+            TinyBLS<Bls12_381, ark_bls12_381::Config>,
+            Bls12_381,
+            ark_bls12_381::Config,
+        >(signed_message);
 
-	assert!(deserialized_signed_message.verify(), "deserialized valid double signed message should verify");
+        assert!(
+            deserialized_signed_message.verify(),
+            "deserialized valid double signed message should verify"
+        );
     }
 
     #[test]
-    fn test_single_bls_message_double_signature_scheme_for_bls12_377() {	
-	test_single_bls_message_double_signature_scheme::<TinyBLS<Bls12_377, ark_bls12_377::Config>, Bls12_377, ark_bls12_377::Config>();
+    fn test_single_bls_message_double_signature_scheme_for_bls12_377() {
+        test_single_bls_message_double_signature_scheme::<
+            TinyBLS<Bls12_377, ark_bls12_377::Config>,
+            Bls12_377,
+            ark_bls12_377::Config,
+        >();
     }
 
     #[test]
-    fn test_single_bls_message_double_signature_scheme_for_bls12_381() {	
-	test_single_bls_message_double_signature_scheme::<TinyBLS<Bls12_381, ark_bls12_381::Config>, Bls12_381, ark_bls12_381::Config>();
+    fn test_single_bls_message_double_signature_scheme_for_bls12_381() {
+        test_single_bls_message_double_signature_scheme::<
+            TinyBLS<Bls12_381, ark_bls12_381::Config>,
+            Bls12_381,
+            ark_bls12_381::Config,
+        >();
     }
-
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2,9 +2,9 @@
 //!
 //! We provide an `EngineBLS` trait that adapts `pairing::Engine`
 //! to BLS-like signatures by permitting the group roles to be
-//! transposed, which involves removing the field of definition, 
+//! transposed, which involves removing the field of definition,
 //! while retaining the correct associations.  
-//! 
+//!
 //! We support same-message aggregation strategies using wrappers
 //! that satisfy `EngineBLS` as well, primarily because these
 //! strategies must ocntroll access to the public key type.
@@ -14,20 +14,26 @@
 //! of both groups.  I think this requires abstracting `CruveAffine`
 //! and `CruveProjective` without their base fields and wNAF windows,
 //! but still with their affine, projective, and compressed forms,
-//! and batch normalization. 
+//! and batch normalization.
 
-use core::borrow::{Borrow};
-use core::ops::{MulAssign};
+use core::borrow::Borrow;
+use core::ops::MulAssign;
 
 use alloc::{vec, vec::Vec};
 
-use ark_serialize::CanonicalSerialize;
-use ark_ff::{Field, PrimeField, UniformRand, Zero};
-use ark_ec::{AffineRepr, CurveGroup, pairing::{Pairing, PairingOutput, MillerLoopOutput}};
-use ark_ec::hashing::{HashToCurve, map_to_curve_hasher::{MapToCurveBasedHasher, MapToCurve}};
-use ark_ff::field_hashers::{DefaultFieldHasher,HashToField};
 use ark_ec::hashing::curve_maps::wb::{WBConfig, WBMap};
-use rand::{Rng};
+use ark_ec::hashing::{
+    map_to_curve_hasher::{MapToCurve, MapToCurveBasedHasher},
+    HashToCurve,
+};
+use ark_ec::{
+    pairing::{MillerLoopOutput, Pairing, PairingOutput},
+    AffineRepr, CurveGroup,
+};
+use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
+use ark_ff::{Field, PrimeField, UniformRand, Zero};
+use ark_serialize::CanonicalSerialize;
+use rand::Rng;
 use rand_core::RngCore;
 
 use core::fmt::Debug;
@@ -49,7 +55,7 @@ use core::marker::PhantomData;
 /// You cannot transpose the two groups in a `pairing::Engine` without
 /// first providing panicing implementations of `pairing::PrimeField`
 /// for `Engine::Fqe`, which is not a prime field, and second,
-/// providing wrapper types for the projective and affine group 
+/// providing wrapper types for the projective and affine group
 /// representations, which makes interacting with the original
 /// `pairing::Engine` annoying.  This trait merely replicates
 /// transposable functionality from `pairing::Engine` by removing
@@ -62,28 +68,29 @@ pub trait EngineBLS {
     type Engine: Pairing; //<Fr = Self::Scalar>;
     type Scalar: PrimeField; // = <Self::Engine as ScalarEngine>::Fr;
     /// Group where BLS public keys live
-    /// 
+    ///
     /// You should take this to be the `Engine::G1` curve usually
     /// becuase all verifiers perform additions on this curve, or
     /// even scalar multiplicaitons with delinearization.
     type PublicKeyGroupBaseField: Field;
-    type PublicKeyGroupAffine:
-    AffineRepr<ScalarField = Self::Scalar, Group = Self::PublicKeyGroup>
+    type PublicKeyGroupAffine: AffineRepr<ScalarField = Self::Scalar, Group = Self::PublicKeyGroup>
         + From<Self::PublicKeyGroup>
         + Into<Self::PublicKeyGroup>
         + Into<Self::PublicKeyPrepared>;
-        //+ Into<<Self::PublicKeyGroup as CurveGroup>::Affine>;
+    //+ Into<<Self::PublicKeyGroup as CurveGroup>::Affine>;
 
-    type PublicKeyGroup: 
-        CurveGroup<Affine = Self::PublicKeyGroupAffine, ScalarField = Self::Scalar, BaseField = Self::PublicKeyGroupBaseField>
-        + From<Self::PublicKeyGroupAffine>
+    type PublicKeyGroup: CurveGroup<
+            Affine = Self::PublicKeyGroupAffine,
+            ScalarField = Self::Scalar,
+            BaseField = Self::PublicKeyGroupBaseField,
+        > + From<Self::PublicKeyGroupAffine>
         + Into<Self::PublicKeyGroupAffine>
-	+ MulAssign<Self::Scalar>;
-    
+        + MulAssign<Self::Scalar>;
+
     type PublicKeyPrepared: Default + Clone + Send + Sync + Debug + From<Self::PublicKeyGroupAffine>;
 
-    const PUBLICKEY_SERIALIZED_SIZE : usize;
-    const SECRET_KEY_SIZE : usize;
+    const PUBLICKEY_SERIALIZED_SIZE: usize;
+    const SECRET_KEY_SIZE: usize;
 
     /// Group where BLS signatures live
     ///
@@ -92,21 +99,23 @@ pub trait EngineBLS {
     /// scalar multiplicaitons with delinearization.
     type SignatureGroupBaseField: Field;
 
-    type SignatureGroupAffine:
-        AffineRepr<ScalarField = Self::Scalar,  Group = Self::SignatureGroup>
+    type SignatureGroupAffine: AffineRepr<ScalarField = Self::Scalar, Group = Self::SignatureGroup>
         + From<Self::SignatureGroup>
         + Into<Self::SignatureGroup>
-	+ Into<Self::SignaturePrepared>;
-    
-    type SignatureGroup:  CurveGroup<Affine = Self::SignatureGroupAffine, ScalarField = Self::Scalar, BaseField = Self::SignatureGroupBaseField>
-        + Into<Self::SignatureGroupAffine>
-	+ From<Self::SignatureGroupAffine>
-	+ MulAssign<Self::Scalar>;
+        + Into<Self::SignaturePrepared>;
+
+    type SignatureGroup: CurveGroup<
+            Affine = Self::SignatureGroupAffine,
+            ScalarField = Self::Scalar,
+            BaseField = Self::SignatureGroupBaseField,
+        > + Into<Self::SignatureGroupAffine>
+        + From<Self::SignatureGroupAffine>
+        + MulAssign<Self::Scalar>;
 
     type SignaturePrepared: Default + Clone + Send + Sync + Debug + From<Self::SignatureGroupAffine>;
 
-    const SIGNATURE_SERIALIZED_SIZE : usize;
-    
+    const SIGNATURE_SERIALIZED_SIZE: usize;
+
     type HashToSignatureField: HashToField<Self::SignatureGroupBaseField>;
     type MapToSignatureCurve: MapToCurve<Self::SignatureGroup>;
 
@@ -116,32 +125,43 @@ pub trait EngineBLS {
     }
 
     /// getter function for the hash to curve map
-    fn hash_to_curve_map() -> MapToCurveBasedHasher::<Self::SignatureGroup, Self::HashToSignatureField, Self::MapToSignatureCurve>;
-    
+    fn hash_to_curve_map() -> MapToCurveBasedHasher<
+        Self::SignatureGroup,
+        Self::HashToSignatureField,
+        Self::MapToSignatureCurve,
+    >;
+
     /// Hash one message to the signature curve.
     fn hash_to_signature_curve<M: Borrow<[u8]>>(message: M) -> Self::SignatureGroup {
-        Self::hash_to_curve_map().hash(message.borrow()).unwrap().into_group()
+        Self::hash_to_curve_map()
+            .hash(message.borrow())
+            .unwrap()
+            .into_group()
     }
 
     /// Run the Miller loop from `Engine` but orients its arguments
     /// to be a `SignatureGroup` and `PublicKeyGroup`.
-    fn miller_loop<'a,I>(i: I) -> MillerLoopOutput<Self::Engine>
+    fn miller_loop<'a, I>(i: I) -> MillerLoopOutput<Self::Engine>
     where
         Self::PublicKeyPrepared: 'a,
         Self::SignaturePrepared: 'a,
-        I: IntoIterator<Item = &'a (
-            <Self as EngineBLS>::PublicKeyPrepared,
-            Self::SignaturePrepared,
-        )>;
+        I: IntoIterator<
+            Item = &'a (
+                <Self as EngineBLS>::PublicKeyPrepared,
+                Self::SignaturePrepared,
+            ),
+        >;
 
     /// Perform final exponentiation on the result of a Miller loop.
-    fn final_exponentiation(e: MillerLoopOutput<Self::Engine>) -> Option<PairingOutput<Self::Engine>> {
+    fn final_exponentiation(
+        e: MillerLoopOutput<Self::Engine>,
+    ) -> Option<PairingOutput<Self::Engine>> {
         Self::Engine::final_exponentiation(e)
     }
 
     /// Performs a pairing operation `e(p, q)` by calling `Engine::pairing`
     /// but orients its arguments to be a `PublicKeyGroup` and `SignatureGroup`.
-    fn pairing<G1,G2>(p: G1, q: G2) -> <Self::Engine as Pairing>::TargetField
+    fn pairing<G1, G2>(p: G1, q: G2) -> <Self::Engine as Pairing>::TargetField
     where
         G1: Into<<Self::PublicKeyGroup as CurveGroup>::Affine>,
         G2: Into<<Self::SignatureGroup as CurveGroup>::Affine>;
@@ -155,29 +175,26 @@ pub trait EngineBLS {
 
     /// Implement verification equation for aggregate BLS signatures
     /// provided as prepared points
-    /// 
+    ///
     /// This low-level routine does no verification of critical security
     /// properties like message distinctness.  It exists purely to
     /// simplify replacing mid-level routines with optimized variants,
-    /// like versions that cache public key preperation or use fewer pairings. 
-    fn verify_prepared<'a,I>(
-        signature: Self::SignaturePrepared,
-        inputs: I
-      ) -> bool
+    /// like versions that cache public key preperation or use fewer pairings.
+    fn verify_prepared<'a, I>(signature: Self::SignaturePrepared, inputs: I) -> bool
     where
         Self::PublicKeyPrepared: 'a,
         Self::SignaturePrepared: 'a,
-        I: IntoIterator<Item = &'a (
-            Self::PublicKeyPrepared,
-            Self::SignaturePrepared,
-        )>
+        I: IntoIterator<Item = &'a (Self::PublicKeyPrepared, Self::SignaturePrepared)>,
     {
-        let lhs: [_;1] = [(Self::minus_generator_of_public_key_group_prepared(),signature)];
-        Self::final_exponentiation( Self::miller_loop(
-            inputs.into_iter().map(|t| t).chain(&lhs)
-	) ).unwrap() == (PairingOutput::<Self::Engine>::zero()) //zero is the target_field::one !!
+        let lhs: [_; 1] = [(
+            Self::minus_generator_of_public_key_group_prepared(),
+            signature,
+        )];
+        Self::final_exponentiation(Self::miller_loop(inputs.into_iter().map(|t| t).chain(&lhs)))
+            .unwrap()
+            == (PairingOutput::<Self::Engine>::zero()) //zero is the target_field::one !!
     }
-    
+
     /// Prepared negative of the generator of the public key curve.
     fn minus_generator_of_public_key_group_prepared() -> Self::PublicKeyPrepared;
 
@@ -195,30 +212,32 @@ pub trait EngineBLS {
     /// by calling either prepare_g1 or prepare_g2 based on which group
     /// is used by the signature system to host the public key
     fn prepare_signature(g: impl Into<Self::SignatureGroupAffine>) -> Self::SignaturePrepared {
-	    let g_affine: Self::SignatureGroupAffine = g.into();
+        let g_affine: Self::SignatureGroupAffine = g.into();
         Self::SignaturePrepared::from(g_affine)
     }
 
     /// Serialization helper for various sigma protocols
     fn signature_point_to_byte(point: &Self::SignatureGroup) -> Vec<u8> {
-	let mut point_as_bytes = vec![0;  Self::SIGNATURE_SERIALIZED_SIZE];
-	let point_affine = point.into_affine();
-	point_affine.serialize_compressed(&mut point_as_bytes[..]).unwrap();
-	point_as_bytes
-    }    
-	
+        let mut point_as_bytes = vec![0; Self::SIGNATURE_SERIALIZED_SIZE];
+        let point_affine = point.into_affine();
+        point_affine
+            .serialize_compressed(&mut point_as_bytes[..])
+            .unwrap();
+        point_as_bytes
+    }
 
     fn public_key_point_to_byte(point: &Self::PublicKeyGroup) -> Vec<u8> {
-	let mut point_as_bytes = vec![0;  Self::PUBLICKEY_SERIALIZED_SIZE];
-	let point_affine = point.into_affine();
-	point_affine.serialize_compressed(&mut point_as_bytes[..]).unwrap();
-	point_as_bytes
-    }    
-
+        let mut point_as_bytes = vec![0; Self::PUBLICKEY_SERIALIZED_SIZE];
+        let point_affine = point.into_affine();
+        point_affine
+            .serialize_compressed(&mut point_as_bytes[..])
+            .unwrap();
+        point_as_bytes
+    }
 }
 
 /// Usual aggregate BLS signature scheme on ZCash's BLS12-381 curve.
-pub type ZBLS = UsualBLS<ark_bls12_381::Bls12_381, ark_bls12_381::Config> ;
+pub type ZBLS = UsualBLS<ark_bls12_381::Bls12_381, ark_bls12_381::Config>;
 pub type BLS377 = UsualBLS<ark_bls12_377::Bls12_377, ark_bls12_377::Config>;
 
 /// Usual aggregate BLS signature scheme on ZCash's BLS12-381 curve.
@@ -228,12 +247,18 @@ pub type BLS377 = UsualBLS<ark_bls12_377::Bls12_377, ark_bls12_377::Config>;
 ///
 /// We favor this variant because verifiers always perform
 /// `O(signers)` additions on the `PublicKeyGroup`, or worse 128 bit
-/// scalar multiplications with delinearization. 
+/// scalar multiplications with delinearization.
 /// We also orient this variant to match zcash's traits.
 #[derive(Default)]
-pub struct UsualBLS<E: Pairing, P: Bls12Config>(pub E, PhantomData<fn() -> P>) where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as Pairing>::G2>;
+pub struct UsualBLS<E: Pairing, P: Bls12Config>(pub E, PhantomData<fn() -> P>)
+where
+    <P as Bls12Config>::G2Config: WBConfig,
+    WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as Pairing>::G2>;
 
-impl<E: Pairing, P: Bls12Config> EngineBLS for UsualBLS<E,P> where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as Pairing>::G2>
+impl<E: Pairing, P: Bls12Config> EngineBLS for UsualBLS<E, P>
+where
+    <P as Bls12Config>::G2Config: WBConfig,
+    WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as Pairing>::G2>,
 {
     type Engine = E;
     type Scalar = <Self::Engine as Pairing>::ScalarField;
@@ -243,68 +268,78 @@ impl<E: Pairing, P: Bls12Config> EngineBLS for UsualBLS<E,P> where <P as Bls12Co
     type PublicKeyPrepared = E::G1Prepared;
     type PublicKeyGroupBaseField = <<E as Pairing>::G1 as CurveGroup>::BaseField;
 
-    const PUBLICKEY_SERIALIZED_SIZE : usize = 48;
-    const SECRET_KEY_SIZE : usize = 32;
+    const PUBLICKEY_SERIALIZED_SIZE: usize = 48;
+    const SECRET_KEY_SIZE: usize = 32;
 
     type SignatureGroup = E::G2;
     type SignatureGroupAffine = E::G2Affine;
     type SignaturePrepared = E::G2Prepared;
-    type SignatureGroupBaseField =  <<E as Pairing>::G2 as CurveGroup>::BaseField;
+    type SignatureGroupBaseField = <<E as Pairing>::G2 as CurveGroup>::BaseField;
 
-    const SIGNATURE_SERIALIZED_SIZE : usize = 96;
+    const SIGNATURE_SERIALIZED_SIZE: usize = 96;
 
     type HashToSignatureField = DefaultFieldHasher<Sha256, 128>;
     type MapToSignatureCurve = WBMap<P::G2Config>;
-    
-    fn miller_loop<'a,I>(i: I) -> MillerLoopOutput<E>
+
+    fn miller_loop<'a, I>(i: I) -> MillerLoopOutput<E>
     where
         // Self::PublicKeyPrepared: 'a,
         // Self::SignaturePrepared: 'a,
-        I: IntoIterator<Item = &'a (
-             Self::PublicKeyPrepared,
-             Self::SignaturePrepared,
-        )>
-	{
-	    let (i_a, i_b) : (Vec<Self::PublicKeyPrepared>, Vec<Self::SignaturePrepared>) = i.into_iter().cloned().unzip();
+        I: IntoIterator<Item = &'a (Self::PublicKeyPrepared, Self::SignaturePrepared)>,
+    {
+        let (i_a, i_b): (Vec<Self::PublicKeyPrepared>, Vec<Self::SignaturePrepared>) =
+            i.into_iter().cloned().unzip();
 
-
-            E::multi_miller_loop(i_a, i_b)
+        E::multi_miller_loop(i_a, i_b)
     }
 
-    fn pairing<G1,G2>(p: G1, q: G2) -> E::TargetField
+    fn pairing<G1, G2>(p: G1, q: G2) -> E::TargetField
     where
         G1: Into<E::G1Affine>,
         G2: Into<E::G2Affine>,
     {
-        E::pairing(p.into(),q.into()).0
+        E::pairing(p.into(), q.into()).0
     }
 
     /// Prepared negative of the generator of the public key curve.
-    fn minus_generator_of_public_key_group_prepared()
-     -> Self::PublicKeyPrepared
-    {
+    fn minus_generator_of_public_key_group_prepared() -> Self::PublicKeyPrepared {
         let g1_minus_generator = <Self::PublicKeyGroup as CurveGroup>::Affine::generator();
-        <Self::PublicKeyGroup as Into<Self::PublicKeyPrepared>>::into(-g1_minus_generator.into_group())
+        <Self::PublicKeyGroup as Into<Self::PublicKeyPrepared>>::into(
+            -g1_minus_generator.into_group(),
+        )
     }
 
-    fn hash_to_curve_map() -> MapToCurveBasedHasher::<Self::SignatureGroup, Self::HashToSignatureField, Self::MapToSignatureCurve> {
-	    MapToCurveBasedHasher::<Self::SignatureGroup, DefaultFieldHasher<Sha256, 128>, WBMap<P::G2Config>>::new(&[1]).unwrap()
+    fn hash_to_curve_map() -> MapToCurveBasedHasher<
+        Self::SignatureGroup,
+        Self::HashToSignatureField,
+        Self::MapToSignatureCurve,
+    > {
+        MapToCurveBasedHasher::<
+            Self::SignatureGroup,
+            DefaultFieldHasher<Sha256, 128>,
+            WBMap<P::G2Config>,
+        >::new(&[1])
+        .unwrap()
     }
-    
 }
-
 
 /// Infrequently used BLS variant with tiny 48 byte signatures and 96 byte public keys,
 ///
 /// We recommend gainst this variant by default because verifiers
 /// always perform `O(signers)` additions on the `PublicKeyGroup`,
-/// or worse 128 bit scalar multiplications with delinearization. 
+/// or worse 128 bit scalar multiplications with delinearization.
 /// Yet, there are specific use cases where this variant performs
 /// better.  We swapy two group roles relative to zcash here.
 #[derive(Default)]
- pub struct TinyBLS<E: Pairing, P: Bls12Config>(pub E, PhantomData<fn() -> P>) where <P as Bls12Config>::G1Config: WBConfig, WBMap<<P as Bls12Config>::G1Config>: MapToCurve<<E as Pairing>::G1>;
+pub struct TinyBLS<E: Pairing, P: Bls12Config>(pub E, PhantomData<fn() -> P>)
+where
+    <P as Bls12Config>::G1Config: WBConfig,
+    WBMap<<P as Bls12Config>::G1Config>: MapToCurve<<E as Pairing>::G1>;
 
-impl<E: Pairing, P: Bls12Config> EngineBLS for TinyBLS<E, P> where <P as Bls12Config>::G1Config: WBConfig, WBMap<<P as Bls12Config>::G1Config>: MapToCurve<<E as Pairing>::G1>
+impl<E: Pairing, P: Bls12Config> EngineBLS for TinyBLS<E, P>
+where
+    <P as Bls12Config>::G1Config: WBConfig,
+    WBMap<<P as Bls12Config>::G1Config>: MapToCurve<<E as Pairing>::G1>,
 {
     type Engine = E;
     type Scalar = <Self::Engine as Pairing>::ScalarField;
@@ -314,54 +349,60 @@ impl<E: Pairing, P: Bls12Config> EngineBLS for TinyBLS<E, P> where <P as Bls12Co
     type SignaturePrepared = E::G1Prepared;
     type SignatureGroupBaseField = <<E as Pairing>::G1 as CurveGroup>::BaseField;
 
-    const SIGNATURE_SERIALIZED_SIZE : usize = 48;
+    const SIGNATURE_SERIALIZED_SIZE: usize = 48;
 
     type PublicKeyGroup = E::G2;
     type PublicKeyGroupAffine = E::G2Affine;
     type PublicKeyPrepared = E::G2Prepared;
     type PublicKeyGroupBaseField = <<E as Pairing>::G2 as CurveGroup>::BaseField;
 
-    const PUBLICKEY_SERIALIZED_SIZE : usize = 96;
-    const SECRET_KEY_SIZE : usize = 32;
+    const PUBLICKEY_SERIALIZED_SIZE: usize = 96;
+    const SECRET_KEY_SIZE: usize = 32;
 
     type HashToSignatureField = DefaultFieldHasher<Sha256, 128>;
     type MapToSignatureCurve = WBMap<P::G1Config>;
 
-    fn miller_loop<'a,I>(i: I) -> MillerLoopOutput<E>
+    fn miller_loop<'a, I>(i: I) -> MillerLoopOutput<E>
     where
-        I: IntoIterator<Item = &'a(
-            Self::PublicKeyPrepared,
-            Self::SignaturePrepared,
-        )>,
+        I: IntoIterator<Item = &'a (Self::PublicKeyPrepared, Self::SignaturePrepared)>,
     {
         // We require an ugly unecessary allocation here because
         // zcash's pairing library cnsumes an iterator of references
-        // to tuples of references, which always requires 
-        let (i_a, i_b) : (Vec<Self::PublicKeyPrepared>, Vec<Self::SignaturePrepared>) = i.into_iter().cloned().unzip();
+        // to tuples of references, which always requires
+        let (i_a, i_b): (Vec<Self::PublicKeyPrepared>, Vec<Self::SignaturePrepared>) =
+            i.into_iter().cloned().unzip();
 
         E::multi_miller_loop(i_b, i_a) //in Tiny BLS signature is in G1
     }
 
-    fn pairing<G2,G1>(p: G2, q: G1) -> E::TargetField
+    fn pairing<G2, G1>(p: G2, q: G1) -> E::TargetField
     where
         G1: Into<E::G1Affine>,
         G2: Into<E::G2Affine>,
     {
-        E::pairing(q.into(),p.into()).0
+        E::pairing(q.into(), p.into()).0
     }
 
     /// Prepared negative of the generator of the public key curve.
-    fn minus_generator_of_public_key_group_prepared()
-     -> Self::PublicKeyPrepared
-    {
+    fn minus_generator_of_public_key_group_prepared() -> Self::PublicKeyPrepared {
         let g2_minus_generator = <Self::PublicKeyGroup as CurveGroup>::Affine::generator();
-        <Self::PublicKeyGroup as Into<Self::PublicKeyPrepared>>::into(-g2_minus_generator.into_group())
+        <Self::PublicKeyGroup as Into<Self::PublicKeyPrepared>>::into(
+            -g2_minus_generator.into_group(),
+        )
     }
 
-        fn hash_to_curve_map() -> MapToCurveBasedHasher::<Self::SignatureGroup, Self::HashToSignatureField, Self::MapToSignatureCurve> {
-	    MapToCurveBasedHasher::<Self::SignatureGroup, DefaultFieldHasher<Sha256, 128>, WBMap<P::G1Config>>::new(&[1]).unwrap()
+    fn hash_to_curve_map() -> MapToCurveBasedHasher<
+        Self::SignatureGroup,
+        Self::HashToSignatureField,
+        Self::MapToSignatureCurve,
+    > {
+        MapToCurveBasedHasher::<
+            Self::SignatureGroup,
+            DefaultFieldHasher<Sha256, 128>,
+            WBMap<P::G1Config>,
+        >::new(&[1])
+        .unwrap()
     }
-
 }
 
 /// Aggregate BLS signature scheme with Signature in G1 for BLS12-377 curve.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,21 @@
-//! # Aggregate BLS signature library with extensive tuning options. 
-//! 
+//! # Aggregate BLS signature library with extensive tuning options.
+//!
 //! In short, anyone using BLS signatures should normally choose both
 //! an orientation as well as some aggregation and batching strategies
 //! These two decissions impact performance dramaticaly, but making
 //! the optimal choises requires some attentiom.  This crate employs
-//! convenient abstraction boundaries between curver arithmatic, 
+//! convenient abstraction boundaries between curver arithmatic,
 //! verifier routines, and aggregated and/or batched BLS signatures.
-//! 
+//!
 //! ### Pairings
-//! 
+//!
 //! If we have two elliptic curve with a pairing `e`, then
 //! a BLS signature `sigma = s*H(msg)` by a public key `S = s g1`
 //! can be verified with the one equation `e(g1,sigma) = e(S,H(msg))`.
 //! These simple BLS signatures are very slow to verify however
 //! because the pairing map `e` is far slower than many cryptographic
 //! primitives.
-//! 
+//!
 //! Our pairing `e` maps from a small curve over `F(q)` and a larger
 //! curve over `F(q^2)` into some multipliccative group if a field,
 //! normally over `F(q^12)`.  In principle, this map `e` into `F(q^12)`
@@ -30,10 +30,10 @@
 //! final exponentiation that happens in `F(q^12)`.  So our actual
 //! verification equation more resembles `e(-g1,sigma) e(S,H(msg)) = 1`.
 //!
-//! As one curve is smaller and hence faster, the user should choose 
+//! As one curve is smaller and hence faster, the user should choose
 //! which orientation of curves they prefer, meaning to which curve
 //! they hash, and which curves hold the signatues and public keys.
-//! In other words, your desired aggregation techniques and usage 
+//! In other words, your desired aggregation techniques and usage
 //! characteristics should determine if youp refer the verification
 //! equation `e(g1,sigma) = e(S,H(msg))` or the fliped form
 //! `e(sigma,g2) = e(H(msg),S)`.  See `UsualBLS` and `TinyBLS`.
@@ -55,17 +55,17 @@
 //! by values unforseeable to the signers.
 //! In general, linear techniques provide much better performance,
 //! but require stronger invariants be maintained by the caller,
-//! like messages being distinct, or limited signer sets with 
+//! like messages being distinct, or limited signer sets with
 //! proofs-of-possession.  Also, the delinearized techniques remain
 //! secure without tricky assumptions, but require more computation.
-//! 
+//!
 //! ### Verification
 //!
 //! We can often further reduce the pairings required in the
 //! verification equation, beyond the naieve information tracked
 //! by the aggregated signature itself.  Aggregated signature must
 //! state all the individual messages and/or public keys, but
-//! verifiers may collapse anything permitted. 
+//! verifiers may collapse anything permitted.
 //! We thus encounter aggregation-like decissions that impact
 //! verifier performance.
 //!
@@ -77,7 +77,7 @@
 //! outputs, but concievably small signer set sizes might make this
 //! a pessimization.
 //!
-//! 
+//!
 //!
 
 //#![feature(test)] needed for cargo bench
@@ -93,13 +93,13 @@ extern crate arrayref;
 extern crate ark_serialize;
 extern crate ark_serialize_derive;
 
-extern crate ark_ff;
 extern crate ark_ec;
-extern crate rand;
-extern crate rand_core;
-extern crate rand_chacha;
-extern crate sha3;
+extern crate ark_ff;
 extern crate digest;
+extern crate rand;
+extern crate rand_chacha;
+extern crate rand_core;
+extern crate sha3;
 
 extern crate alloc;
 
@@ -109,31 +109,31 @@ extern crate serde;
 use core::borrow::Borrow;
 use digest::Digest;
 
-pub mod serialize;
-pub mod engine;
-pub mod single;
-pub mod double;
-pub mod schnorr_pop;
-pub mod chaum_pedersen_signature;
-pub mod verifiers;
 #[cfg(feature = "std")]
-pub mod pop;
+pub mod bit;
+pub mod chaum_pedersen_signature;
+#[cfg(feature = "std")]
+pub mod delinear;
+#[cfg(feature = "std")]
+pub mod distinct;
+pub mod double;
+pub mod engine;
 #[cfg(feature = "std")]
 pub mod multi_pop_aggregator;
 #[cfg(feature = "std")]
-pub mod distinct;
-#[cfg(feature = "std")]
-pub mod bit;
-#[cfg(feature = "std")]
-pub mod delinear;
+pub mod pop;
+pub mod schnorr_pop;
+pub mod serialize;
+pub mod single;
+pub mod verifiers;
 
 pub use engine::*;
 
-pub use serialize::SerializableToBytes;
-pub use single::{PublicKey,KeypairVT,Keypair,SecretKeyVT,SecretKey,Signature, SignedMessage,};
 #[cfg(feature = "std")]
-pub use bit::{BitSignedMessage,CountSignedMessage};
+pub use bit::{BitSignedMessage, CountSignedMessage};
 pub use schnorr_pop::SchnorrProof;
+pub use serialize::SerializableToBytes;
+pub use single::{Keypair, KeypairVT, PublicKey, SecretKey, SecretKeyVT, Signature, SignedMessage};
 
 /// Internal message hash size.  
 ///
@@ -141,14 +141,18 @@ pub use schnorr_pop::SchnorrProof;
 /// find messages with the same hash.
 const MESSAGE_SIZE: usize = 32;
 
+type MessageDigest = [u8; MESSAGE_SIZE];
 /// Internal message hash type.  Short for frequent rehashing
 /// by `HashMap`, etc.
-#[derive(Debug,Copy,Clone,Hash,PartialEq,Eq,PartialOrd,Ord)]
-pub struct Message(pub [u8; MESSAGE_SIZE]);
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Message(pub MessageDigest, pub Vec<u8>);
 
 impl Message {
     pub fn new(context: &'static [u8], message: &[u8]) -> Message {
-        use sha3::{Shake128, digest::{Update, ExtendableOutput, XofReader}};
+        use sha3::{
+            digest::{ExtendableOutput, Update, XofReader},
+            Shake128,
+        };
         let mut h = Shake128::default();
         h.update(context);
         let l = message.len() as u64;
@@ -159,16 +163,18 @@ impl Message {
         let mut msg = [0u8; MESSAGE_SIZE];
         h.finalize_xof().read(&mut msg[..]);
         // t.challenge_bytes(b"", &mut msg);
-        Message(msg)
+        Message(msg, [context, message].concat())
     }
 
     pub fn hash_to_signature_curve<E: EngineBLS>(&self) -> E::SignatureGroup {
-        E::hash_to_signature_curve(&self.0[..])
+        E::hash_to_signature_curve(&self.1[..])
     }
 }
 
 impl<'a> From<&'a [u8]> for Message {
-    fn from(x: &[u8]) -> Message { Message::new(b"",x) }     
+    fn from(x: &[u8]) -> Message {
+        Message::new(b"", x)
+    }
 }
 
 /// Representation of an aggregated BLS signature.
@@ -184,21 +190,21 @@ impl<'a> From<&'a [u8]> for Message {
 pub trait Signed: Sized {
     type E: EngineBLS;
 
-    /// Return the aggregated signature 
+    /// Return the aggregated signature
     fn signature(&self) -> Signature<Self::E>;
 
     type M: Borrow<Message>; // = Message;
     type PKG: Borrow<PublicKey<Self::E>>; // = PublicKey<Self::E>;
 
     /// Iterator over, messages and public key reference pairs.
-    type PKnM: Iterator<Item = (Self::M,Self::PKG)> + ExactSizeIterator;
+    type PKnM: Iterator<Item = (Self::M, Self::PKG)> + ExactSizeIterator;
     // type PKnM<'a>: Iterator<Item = (
     //    &'a <<Self as Signed<'a>>::E as EngineBLS>::PublicKeyGroup,
     //    &'a Self::M,
     // )> + DoubleEndedIterator + ExactSizeIterator + 'a;
 
     /// Returns an iterator over messages and public key reference for
-    /// pairings, often only partially aggregated. 
+    /// pairings, often only partially aggregated.
     fn messages_and_publickeys(self) -> Self::PKnM;
     // fn messages_and_publickeys<'a>(&'s self) -> PKnM<'a>
     // -> impl Iterator<Item = (&'a Self::M, &'a Self::E::PublicKeyGroup)> + 'a;
@@ -209,7 +215,7 @@ pub trait Signed: Sized {
     /// it supports unstable `self.messages_and_publickeys()` securely
     /// by calling it only once, and does not expect pulic key points
     /// to be normalized, but this should usually be replaced by more
-    /// optimized variants. 
+    /// optimized variants.
     fn verify(self) -> bool {
         verifiers::verify_simple(self)
     }
@@ -224,7 +230,7 @@ pub trait ProofOfPossessionGenerator<E: EngineBLS, H: Digest> {
 }
 
 /// This should be implemented by public key
-pub trait ProofOfPossessionVerifier<E: EngineBLS, H: Digest> { 
+pub trait ProofOfPossessionVerifier<E: EngineBLS, H: Digest> {
     fn verify_pok(&self, schnorr_proof: SchnorrProof<E>) -> bool;
 }
 
@@ -237,4 +243,3 @@ pub trait ProofOfPossessionVerifier<E: EngineBLS, H: Digest> {
 //     // #[test]
 //     // fn foo() { }
 // }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,12 +81,12 @@
 //!
 
 //#![feature(test)] needed for cargo bench
-
 #![cfg_attr(not(feature = "std"), no_std)]
 #[cfg_attr(feature = "std", doc = include_str!("../README.md"))]
 #[cfg(doctest)]
 pub struct ReadmeDoctests;
 
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate arrayref;
 
@@ -146,7 +146,7 @@ type MessageDigest = [u8; MESSAGE_SIZE];
 /// Internal message hash type.  Short for frequent rehashing
 /// by `HashMap`, etc.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Message(pub MessageDigest, pub Vec<u8>);
+pub struct Message(pub MessageDigest, pub alloc::vec::Vec<u8>);
 
 impl Message {
     pub fn new(context: &'static [u8], message: &[u8]) -> Message {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,12 +129,12 @@ pub mod verifiers;
 
 pub use engine::*;
 
-pub use serialize::SerializableToBytes;
-pub use single::{PublicKey,KeypairVT,Keypair,SecretKeyVT,SecretKey,Signature, SignedMessage,};
-pub use double::{DoublePublicKey, DoublePublicKeyScheme, DoubleSignature};
 #[cfg(feature = "std")]
 pub use bit::{BitSignedMessage, CountSignedMessage};
+pub use double::{DoublePublicKey, DoublePublicKeyScheme, DoubleSignature};
 pub use schnorr_pop::SchnorrProof;
+pub use serialize::SerializableToBytes;
+pub use single::{Keypair, KeypairVT, PublicKey, SecretKey, SecretKeyVT, Signature, SignedMessage};
 
 /// Internal message hash size.  
 ///

--- a/src/multi_pop_aggregator.rs
+++ b/src/multi_pop_aggregator.rs
@@ -1,6 +1,6 @@
-//! ## Aggregation of BLS signatures using proofs-of-possession 
+//! ## Aggregation of BLS signatures using proofs-of-possession
 //!
-//! In this module, we provide the linear flavor of aggregate 
+//! In this module, we provide the linear flavor of aggregate
 //! BLS signature in which the verifiers has previously checked
 //! proofs-of-possession for all public keys.  In other words,
 //! we simply add up the signatures because the previously checked
@@ -13,7 +13,7 @@
 //! so a BLS signature by each secret key on its own public key.
 //! Importantly, the message for this self-signed certificates
 //! must uniquely distinguish the public key for which the signature
-//! establishes a proof-of-possession. 
+//! establishes a proof-of-possession.
 //! It follows that each proof-of-possession has a unique message,
 //! so distinct message aggregation is optimal for verifying them.
 //!
@@ -34,18 +34,18 @@
 // Aside about proof-of-possession in the DLOG setting
 // https://twitter.com/btcVeg/status/1085490561082183681
 
-use core::borrow::{Borrow}; // BorrowMut
+use core::borrow::Borrow; // BorrowMut
 use std::collections::HashMap;
 
-use ark_ff::{Zero};
+use ark_ff::Zero;
 
+use super::verifiers::verify_with_distinct_messages;
 use super::*;
-use super::verifiers::{verify_with_distinct_messages,};
 
 /// Batch or aggregate BLS signatures with attached messages and
 /// signers, for whom we previously checked proofs-of-possession.
 ///
-/// In this type, we provide a high-risk low-level batching and 
+/// In this type, we provide a high-risk low-level batching and
 /// aggregation mechanism that merely adds up signatures under the
 /// assumption that all required proofs-of-possession were previously
 /// checked.
@@ -78,13 +78,12 @@ use super::verifiers::{verify_with_distinct_messages,};
 /// but this sounds complex or worse fragile.
 ///
 // TODO: Implement gaussian elimination verification scheme.
-
-use single::{PublicKey};
+use single::PublicKey;
 /// ProofOfPossion trait which should be implemented by secret
 
 #[derive(Clone)]
-pub struct MultiMessageSignatureAggregatorAssumingPoP <E: EngineBLS> {
-    messages_n_publickeys: HashMap<Message,PublicKey<E>>,    
+pub struct MultiMessageSignatureAggregatorAssumingPoP<E: EngineBLS> {
+    messages_n_publickeys: HashMap<Message, PublicKey<E>>,
     signature: Signature<E>,
 }
 
@@ -109,179 +108,203 @@ impl<E: EngineBLS> MultiMessageSignatureAggregatorAssumingPoP<E> {
     /// Useful for constructing an aggregate signature, but we
     /// recommend instead using a custom types like `BitPoPSignedMessage`.
     pub fn add_message_n_publickey(&mut self, message: &Message, publickey: &PublicKey<E>) {
-        self.messages_n_publickeys.entry(*message)
-            .and_modify(|pk0| pk0.0 += &publickey.0 )
+        self.messages_n_publickeys
+            .entry(message.clone())
+            .and_modify(|pk0| pk0.0 += &publickey.0)
             .or_insert(*publickey);
     }
 
     /// Aggregage BLS signatures assuming they have proofs-of-possession
-    pub fn aggregate<'a,S>(&mut self, signed: &'a S) 
+    pub fn aggregate<'a, S>(&mut self, signed: &'a S)
     where
-        &'a S: Signed<E=E>,
+        &'a S: Signed<E = E>,
         <&'a S as Signed>::PKG: Borrow<PublicKey<E>>,
     {
         let signature = signed.signature();
-        for (message,pubickey) in signed.messages_and_publickeys() {
-            self.add_message_n_publickey(message.borrow(),pubickey.borrow());
+        for (message, pubickey) in signed.messages_and_publickeys() {
+            self.add_message_n_publickey(message.borrow(), pubickey.borrow());
         }
         self.add_signature(&signature);
     }
-    
 }
 
-impl<'a,E: EngineBLS> Signed for &'a MultiMessageSignatureAggregatorAssumingPoP<E> {
+impl<'a, E: EngineBLS> Signed for &'a MultiMessageSignatureAggregatorAssumingPoP<E> {
     type E = E;
 
     type M = &'a Message;
     type PKG = &'a PublicKey<Self::E>;
-    type PKnM = ::std::collections::hash_map::Iter<'a,Message,PublicKey<E>>;
+    type PKnM = ::std::collections::hash_map::Iter<'a, Message, PublicKey<E>>;
 
     fn messages_and_publickeys(self) -> Self::PKnM {
         self.messages_n_publickeys.iter()
     }
 
-    fn signature(&self) -> Signature<E> { self.signature }
+    fn signature(&self) -> Signature<E> {
+        self.signature
+    }
 
     fn verify(self) -> bool {
         // We have already aggregated distinct messages, so our distinct
         // message verification code provides reasonable optimizations,
-        // except the public keys might not be normalized here. 
+        // except the public keys might not be normalized here.
         // We foresee verification via gaussian elimination being faster,
         // but requires affine keys or normalization.
-        verify_with_distinct_messages(self,true)
+        verify_with_distinct_messages(self, true)
         // TODO: verify_with_gaussian_elimination(self)
     }
 }
 
-
-#[cfg(all(test, feature="std"))]
+#[cfg(all(test, feature = "std"))]
 mod tests {
 
-    use crate::Message;
     use crate::Keypair;
+    use crate::Message;
     use crate::UsualBLS;
     use rand::thread_rng;
 
     use ark_bls12_381::Bls12_381;
 
     use super::*;
-    use crate::double::DoublePublicKeyScheme;
-    
+
     #[test]
     fn verify_aggregate_single_message_single_signer() {
-        let good = Message::new(b"ctx",b"test message");
+        let good = Message::new(b"ctx", b"test message");
 
-        let mut keypair  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-        let good_sig0 = keypair.sign(good);
-        assert!(good_sig0.verify(good, &keypair.public));
-        
+        let mut keypair =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig0 = keypair.sign(&good);
+        assert!(good_sig0.verify(&good, &keypair.public));
     }
 
     #[test]
     fn verify_aggregate_single_message_multi_signers() {
-        let good = Message::new(b"ctx",b"test message");
+        let good = Message::new(b"ctx", b"test message");
 
-        let mut keypair0  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-        let good_sig0 = keypair0.sign(good);
+        let mut keypair0 =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig0 = keypair0.sign(&good);
 
-        let mut keypair1  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-        let good_sig1 = keypair1.sign(good);
+        let mut keypair1 =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig1 = keypair1.sign(&good);
 
-        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::new();
+        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<
+            UsualBLS<Bls12_381, ark_bls12_381::Config>,
+        >::new();
         aggregated_sigs.add_signature(&good_sig0);
         aggregated_sigs.add_signature(&good_sig1);
 
         aggregated_sigs.add_message_n_publickey(&good, &keypair0.public);
         aggregated_sigs.add_message_n_publickey(&good, &keypair1.public);
 
-        assert!(aggregated_sigs.verify() == true, "good aggregated signature of a single message with multiple key does not verify");
-
+        assert!(
+            aggregated_sigs.verify() == true,
+            "good aggregated signature of a single message with multiple key does not verify"
+        );
     }
 
     #[test]
     fn verify_aggregate_multi_messages_single_signer() {
-        let good0 = Message::new(b"ctx",b"Tab over Space");
-        let good1 = Message::new(b"ctx",b"Space over Tab");
+        let good0 = Message::new(b"ctx", b"Tab over Space");
+        let good1 = Message::new(b"ctx", b"Space over Tab");
 
-        let mut keypair  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let mut keypair =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
 
-        let good_sig0 = keypair.sign(good0);
-        let good_sig1 = keypair.sign(good1);
+        let good_sig0 = keypair.sign(&good0);
+        let good_sig1 = keypair.sign(&good1);
 
-        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::new();
+        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<
+            UsualBLS<Bls12_381, ark_bls12_381::Config>,
+        >::new();
         aggregated_sigs.add_signature(&good_sig0);
         aggregated_sigs.add_signature(&good_sig1);
 
         aggregated_sigs.add_message_n_publickey(&good0, &keypair.public);
         aggregated_sigs.add_message_n_publickey(&good1, &keypair.public);
 
-        assert!(aggregated_sigs.verify() == true, "good aggregated signature of multiple messages with a single key does not verify");
-        
+        assert!(
+            aggregated_sigs.verify() == true,
+            "good aggregated signature of multiple messages with a single key does not verify"
+        );
     }
 
     #[test]
     fn verify_aggregate_multi_messages_multi_signers() {
-        let good0 = Message::new(b"ctx",b"in the beginning");
-        let good1 = Message::new(b"ctx",b"there was a flying spaghetti monster");
+        let good0 = Message::new(b"ctx", b"in the beginning");
+        let good1 = Message::new(b"ctx", b"there was a flying spaghetti monster");
 
-        let mut keypair0  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-        let good_sig0 = keypair0.sign(good0);
+        let mut keypair0 =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig0 = keypair0.sign(&good0);
 
-        let mut keypair1  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-        let good_sig1 = keypair1.sign(good1);
+        let mut keypair1 =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig1 = keypair1.sign(&good1);
 
-        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::new();
+        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<
+            UsualBLS<Bls12_381, ark_bls12_381::Config>,
+        >::new();
         aggregated_sigs.add_signature(&good_sig0);
         aggregated_sigs.add_signature(&good_sig1);
 
         aggregated_sigs.add_message_n_publickey(&good0, &keypair0.public);
         aggregated_sigs.add_message_n_publickey(&good1, &keypair1.public);
 
-        assert!(aggregated_sigs.verify() == true, "good aggregated signature of multiple messages with multiple keys does not verify");
+        assert!(
+            aggregated_sigs.verify() == true,
+            "good aggregated signature of multiple messages with multiple keys does not verify"
+        );
     }
 
     #[test]
     fn verify_aggregate_single_message_repetative_signers() {
-        let good = Message::new(b"ctx",b"test message");
+        let good = Message::new(b"ctx", b"test message");
 
-        let mut keypair  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-        let good_sig = keypair.sign(good);
+        let mut keypair =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig = keypair.sign(&good);
 
-        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::new();
+        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<
+            UsualBLS<Bls12_381, ark_bls12_381::Config>,
+        >::new();
         aggregated_sigs.add_signature(&good_sig);
         aggregated_sigs.add_signature(&good_sig);
 
         aggregated_sigs.add_message_n_publickey(&good, &keypair.public);
         aggregated_sigs.add_message_n_publickey(&good, &keypair.public);
 
-        assert!(aggregated_sigs.verify() == true, "good aggregate of a repetitive signature does not verify");
+        assert!(
+            aggregated_sigs.verify() == true,
+            "good aggregate of a repetitive signature does not verify"
+        );
     }
 
     #[test]
     fn aggregate_of_signature_of_a_wrong_message_should_not_verify() {
-        let good0 = Message::new(b"ctx",b"Space over Tab");
-        let bad1 = Message::new(b"ctx",b"Tab over Space");
+        let good0 = Message::new(b"ctx", b"Space over Tab");
+        let bad1 = Message::new(b"ctx", b"Tab over Space");
 
-        let mut keypair0  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-        let good_sig0 = keypair0.sign(good0);
+        let mut keypair0 =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig0 = keypair0.sign(&good0);
 
-        let mut keypair1  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-        let bad_sig1 = keypair1.sign(bad1);
+        let mut keypair1 =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let bad_sig1 = keypair1.sign(&bad1);
 
-        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::new();
+        let mut aggregated_sigs = MultiMessageSignatureAggregatorAssumingPoP::<
+            UsualBLS<Bls12_381, ark_bls12_381::Config>,
+        >::new();
         aggregated_sigs.add_signature(&good_sig0);
         aggregated_sigs.add_signature(&bad_sig1);
 
         aggregated_sigs.add_message_n_publickey(&good0, &keypair0.public);
         aggregated_sigs.add_message_n_publickey(&good0, &keypair1.public);
 
-        assert!(aggregated_sigs.verify() == false, "aggregated signature of a wrong message should not verify");
+        assert!(
+            aggregated_sigs.verify() == false,
+            "aggregated signature of a wrong message should not verify"
+        );
     }
-
-    fn generate_many_keypairs(num_of_keypairs: usize)-> Vec::<Keypair::<TinyBLS377>> {
-        let mut keypairs : Vec::<Keypair::<TinyBLS377>>  = (0..num_of_keypairs).map(|_| Keypair::<TinyBLS377>::generate(thread_rng())).collect();
-        keypairs
-        
-    }
-
 }

--- a/src/schnorr_pop.rs
+++ b/src/schnorr_pop.rs
@@ -1,45 +1,47 @@
 //! ## Implementation of ProofofPossion trait for BLS keys using schnorr sginature
 //! ## TODO: I assume this can also moved to pop.rs but for now I put it separately to help reviews
-use crate::engine::{EngineBLS};
+use crate::engine::EngineBLS;
 use crate::{ProofOfPossessionGenerator, ProofOfPossessionVerifier};
 
 use crate::serialize::SerializableToBytes;
-use crate::single::{PublicKey,Keypair};
+use crate::single::{Keypair, PublicKey};
 
-use digest::{Digest};
+use digest::Digest;
 
-use ark_ec::{Group, };
-use ark_ff::{PrimeField};
+use ark_ec::Group;
+use ark_ff::PrimeField;
 
 pub type SchnorrProof<E> = (<E as EngineBLS>::Scalar, <E as EngineBLS>::Scalar);
 // }
 /// Generate Schnorr Signature for an arbitrary message using a key ment to use in BLS scheme
-trait BLSSchnorrPoPGenerator<E: EngineBLS, H: Digest> : ProofOfPossessionGenerator<E,H> {
+trait BLSSchnorrPoPGenerator<E: EngineBLS, H: Digest>: ProofOfPossessionGenerator<E, H> {
     /// Produce a secret witness scalar `k`, aka nonce, from hash of
     /// H( H(s) | H(public_key)) because our key does not have the
     /// randomness redundacy exists in EdDSA secret key.
     fn witness_scalar(&self) -> <<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField;
 }
 
-impl<E: EngineBLS, H: Digest> BLSSchnorrPoPGenerator<E,H> for Keypair<E>
-{
+impl<E: EngineBLS, H: Digest> BLSSchnorrPoPGenerator<E, H> for Keypair<E> {
     //The pseudo random witness is generated similar to eddsa witness
     //hash(secret_key|publick_key)
     fn witness_scalar(&self) -> <<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField {
         let secret_key_as_bytes = self.secret.to_bytes();
         let public_key_as_bytes = <E as EngineBLS>::public_key_point_to_byte(&self.public.0);
-        
-        let mut scalar_bytes = <H as Digest>::new().chain_update(secret_key_as_bytes).chain_update(public_key_as_bytes).finalize();
 
-	let random_scalar : &mut [u8] = scalar_bytes.as_mut_slice();
-        <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(&*random_scalar)
+        let mut scalar_bytes = <H as Digest>::new()
+            .chain_update(secret_key_as_bytes)
+            .chain_update(public_key_as_bytes)
+            .finalize();
+
+        let random_scalar: &mut [u8] = scalar_bytes.as_mut_slice();
+        <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(
+            &*random_scalar,
+        )
     }
-
 }
 
-impl<E: EngineBLS, H: Digest> ProofOfPossessionGenerator<E,H> for Keypair<E> {
-
-    //TODO: Message must be equal to public key. 
+impl<E: EngineBLS, H: Digest> ProofOfPossessionGenerator<E, H> for Keypair<E> {
+    //TODO: Message must be equal to public key.
     fn generate_pok(&self) -> SchnorrProof<E> {
         //First we should figure out the base point in E, I think the secret key trait/struct knows about it.
 
@@ -55,28 +57,33 @@ impl<E: EngineBLS, H: Digest> ProofOfPossessionGenerator<E,H> for Keypair<E> {
         // publishing (s, R) verifying that (s*G = H(R|M)*Publickey + R => H(R|M)*Publickey + R - s*G = 0)
         // so either we need to two into_affine and one curve addition or or two curve additions.
         // instead we actually doing H(s*G - H(R|M)*Publickey|M) == H(R|M) == k
-	// avoiding one curve addition (or two field divisions) in expense of a hash.
-        let mut r = <dyn BLSSchnorrPoPGenerator<E,H>>::witness_scalar(self);
-        
+        // avoiding one curve addition (or two field divisions) in expense of a hash.
+        let mut r = <dyn BLSSchnorrPoPGenerator<E, H>>::witness_scalar(self);
+
         let mut r_point = <<E as EngineBLS>::PublicKeyGroup as Group>::generator();
         r_point *= r; //todo perhaps we need to mandate E to have  a hard coded point
 
         let r_point_as_bytes = <E as EngineBLS>::public_key_point_to_byte(&r_point);
-	let public_key_as_bytes = <E as EngineBLS>::public_key_point_to_byte(&self.public.0); //it *must* be the public key (fixed) otherwise secret key can be recovered from the two different proves
+        let public_key_as_bytes = <E as EngineBLS>::public_key_point_to_byte(&self.public.0); //it *must* be the public key (fixed) otherwise secret key can be recovered from the two different proves
 
-        let mut k_as_hash = <H as Digest>::new().chain_update(r_point_as_bytes).chain_update(public_key_as_bytes).finalize();
-	let random_scalar : &mut [u8] = k_as_hash.as_mut_slice();
+        let mut k_as_hash = <H as Digest>::new()
+            .chain_update(r_point_as_bytes)
+            .chain_update(public_key_as_bytes)
+            .finalize();
+        let random_scalar: &mut [u8] = k_as_hash.as_mut_slice();
 
-        let k = <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(&*random_scalar);
+        let k = <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(
+            &*random_scalar,
+        );
         let s = (k * self.secret.into_vartime().0) + r;
 
         ::zeroize::Zeroize::zeroize(&mut r); //clear secret witness from memory
 
-        (s,k)
+        (s, k)
     }
 }
 
-impl<E: EngineBLS, H: Digest> ProofOfPossessionVerifier<E,H> for PublicKey<E> {
+impl<E: EngineBLS, H: Digest> ProofOfPossessionVerifier<E, H> for PublicKey<E> {
     /// verify the validity of schnoor proof for a given publick key by
     /// making sure this is equal to zero
     /// H(+s*G - k*Publkey|M) ==  k  
@@ -88,46 +95,49 @@ impl<E: EngineBLS, H: Digest> ProofOfPossessionVerifier<E,H> for PublicKey<E> {
         schnorr_point += k_public_key;
 
         let schnorr_point_as_bytes = <E as EngineBLS>::public_key_point_to_byte(&schnorr_point);
-	let public_key_as_bytes = <E as EngineBLS>::public_key_point_to_byte(&self.0); //it *must* be the public key (fixed) otherwise secret key can be recovered from the two different proves
+        let public_key_as_bytes = <E as EngineBLS>::public_key_point_to_byte(&self.0); //it *must* be the public key (fixed) otherwise secret key can be recovered from the two different proves
 
-        let mut scalar_bytes = <H as Digest>::new().chain_update(schnorr_point_as_bytes).chain_update(public_key_as_bytes).finalize();
+        let mut scalar_bytes = <H as Digest>::new()
+            .chain_update(schnorr_point_as_bytes)
+            .chain_update(public_key_as_bytes)
+            .finalize();
 
-        let random_scalar = <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(scalar_bytes.as_mut_slice());
-	random_scalar == schnorr_proof.1
-	}
+        let random_scalar =
+            <<<E as EngineBLS>::PublicKeyGroup as Group>::ScalarField>::from_be_bytes_mod_order(
+                scalar_bytes.as_mut_slice(),
+            );
+        random_scalar == schnorr_proof.1
+    }
 }
 
-#[cfg(all(test,feature="std"))]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     #[test]
     fn bls_pop_sign() {
-        use crate::{ProofOfPossessionGenerator};
-        use crate::single::{Keypair};
-        use crate::engine::{ZBLS};
-        use crate::Message;
-        use rand::{thread_rng};
-        use sha2::Sha512;    
+        use crate::engine::ZBLS;
+        use crate::single::Keypair;
+        use crate::ProofOfPossessionGenerator;
+        use rand::thread_rng;
+        use sha2::Sha512;
 
-        let keypair  = Keypair::<ZBLS>::generate(thread_rng());
+        let keypair = Keypair::<ZBLS>::generate(thread_rng());
         <Keypair<ZBLS> as ProofOfPossessionGenerator<ZBLS, Sha512>>::generate_pok(&keypair);
     }
 
     #[test]
-    fn bls_pop_sign_and_verify()
-    {
-        use rand::{thread_rng};
-        use sha2::Sha512;    
+    fn bls_pop_sign_and_verify() {
+        use rand::thread_rng;
+        use sha2::Sha512;
 
-        use crate::single::{Keypair};
-        use crate::engine::{ZBLS};
-        use crate::Message;
+        use crate::engine::ZBLS;
+        use crate::single::Keypair;
         use crate::{ProofOfPossessionGenerator, ProofOfPossessionVerifier};
 
-
-        let keypair  = Keypair::<ZBLS>::generate(thread_rng());
+        let keypair = Keypair::<ZBLS>::generate(thread_rng());
         let proof_pair = <dyn ProofOfPossessionGenerator<ZBLS, Sha512>>::generate_pok(&keypair);
-        assert!(<ProofOfPossessionVerifier<ZBLS, Sha512>>::verify_pok(&keypair.public, proof_pair), "valid pok does not verify")
-
+        assert!(
+            <dyn ProofOfPossessionVerifier<ZBLS, Sha512>>::verify_pok(&keypair.public, proof_pair),
+            "valid pok does not verify"
+        )
     }
-    
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,24 +1,21 @@
-use ark_serialize::{SerializationError, CanonicalSerialize, CanonicalDeserialize,};
 use alloc::{vec, vec::Vec};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 
 /// Serialization code that is used by multiple modules.
 // Note that ark_ff::bytes::ToBytes for projective points export them without converting them to affine
 // and so they might leak information about the secret key.
-pub trait SerializableToBytes:
-    CanonicalSerialize +
-    CanonicalDeserialize 
-{
-    const SERIALIZED_BYTES_SIZE : usize;
-	
+pub trait SerializableToBytes: CanonicalSerialize + CanonicalDeserialize {
+    const SERIALIZED_BYTES_SIZE: usize;
+
     fn to_bytes(&self) -> Vec<u8> {
-        let mut serialized_representation : Vec<u8> = vec![0; Self::SERIALIZED_BYTES_SIZE];
-        self.serialize_compressed(&mut serialized_representation[..]).unwrap();
+        let mut serialized_representation: Vec<u8> = vec![0; Self::SERIALIZED_BYTES_SIZE];
+        self.serialize_compressed(&mut serialized_representation[..])
+            .unwrap();
 
         return serialized_representation;
+    }
 
-     }
-
-    fn from_bytes(bytes: &[u8]) -> Result<Self,SerializationError>  {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
         Self::deserialize_compressed(bytes)
-     }
+    }
 }

--- a/src/single.rs
+++ b/src/single.rs
@@ -15,7 +15,7 @@
 //! We imagine this simplification helps focus on more important
 //! optimizations, like placing `batch_normalization` calls well.
 //! We could exploit `CurveGroup: += _mixed` function
-//! if we had seperate types for affine points, but if doing so 
+//! if we had seperate types for affine points, but if doing so
 //! improved performance enough then we instead suggest tweaking
 //! `CurveGroup::add_mixed` to test for normalized points.
 //!
@@ -25,25 +25,31 @@
 
 use alloc::{vec, vec::Vec};
 
+use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
 use ark_ff::{UniformRand, Zero};
-use ark_ff::field_hashers::{DefaultFieldHasher,HashToField};
-       
-use ark_ec::{CurveGroup,AffineRepr,};
 
-use ark_serialize::{SerializationError, Read, Write, CanonicalSerialize, CanonicalDeserialize, Valid, Validate, Compress};
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use ark_ec::{AffineRepr, CurveGroup};
+
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid, Validate,
+    Write,
+};
 #[cfg(feature = "std")]
 use rand::thread_rng;
-use sha3::{Shake128, digest::{Update,  ExtendableOutput, XofReader}};
-use sha2::Sha256;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
+use sha2::Sha256;
+use sha3::{
+    digest::{ExtendableOutput, Update, XofReader},
+    Shake128,
+};
 
-use digest::{Digest};
+use digest::Digest;
 
 use core::iter::once;
 
 use crate::serialize::SerializableToBytes;
-use crate::{EngineBLS, Message, Signed,};
+use crate::{EngineBLS, Message, Signed};
 // //////////////// SECRETS //////////////// //
 
 /// Secret signing key lacking the side channel protections from
@@ -52,29 +58,30 @@ use crate::{EngineBLS, Message, Signed,};
 pub struct SecretKeyVT<E: EngineBLS>(pub E::Scalar);
 
 impl<E: EngineBLS> Clone for SecretKeyVT<E> {
-    fn clone(&self) -> Self { SecretKeyVT(self.0) }
+    fn clone(&self) -> Self {
+        SecretKeyVT(self.0)
+    }
 }
 
 impl<E: EngineBLS> SecretKeyVT<E> {
     /// Generate a secret key without side channel protections.
     pub fn generate<R: Rng>(mut rng: R) -> Self {
-        SecretKeyVT( E::generate(&mut rng) )
+        SecretKeyVT(E::generate(&mut rng))
     }
 
     pub fn from_seed(seed: &[u8]) -> Self {
         let hasher = <DefaultFieldHasher<Sha256> as HashToField<E::Scalar>>::new(&[]);
         return SecretKeyVT(hasher.hash_to_field(seed, 1)[0]);
     }
-
 }
 
 impl<E: EngineBLS> SecretKeyVT<E> {
     /// Sign without side channel protections from key mutation.
-    pub fn sign(&self, message: Message) -> Signature<E> {
-        let mut s : E::SignatureGroup = message.hash_to_signature_curve::<E>();
+    pub fn sign(&self, message: &Message) -> Signature<E> {
+        let mut s: E::SignatureGroup = message.hash_to_signature_curve::<E>();
         s *= self.0;
         // s.normalize();   // VRFs are faster if we only normalize once, but no normalize method exists.
-        // E::SignatureGroup::batch_normalization(&mut [&mut s]);  
+        // E::SignatureGroup::batch_normalization(&mut [&mut s]);
         Signature(s)
     }
 
@@ -82,10 +89,10 @@ impl<E: EngineBLS> SecretKeyVT<E> {
     /// but does not itself resplit the key.
     pub fn into_split_dirty(&self) -> SecretKey<E> {
         SecretKey {
-            key: [ self.0.clone(), E::Scalar::zero() ],
+            key: [self.0.clone(), E::Scalar::zero()],
             old_unsigned: E::SignatureGroup::zero(),
             old_signed: E::SignatureGroup::zero(),
-        } 
+        }
     }
 
     /// Convert into a `SecretKey` applying side channel protections.
@@ -99,13 +106,12 @@ impl<E: EngineBLS> SecretKeyVT<E> {
     /// Derive our public key from our secret key
     pub fn into_public(&self) -> PublicKey<E> {
         // TODO str4d never decided on projective vs affine here, so benchmark both versions.
-        PublicKey( <E::PublicKeyGroup as CurveGroup>::Affine::generator().into_group()*self.0)
+        PublicKey(<E::PublicKeyGroup as CurveGroup>::Affine::generator().into_group() * self.0)
         // let mut g = <E::PublicKeyGroup as CurveGroup>::one();
         // g *= self.0;
         // PublicKey(p)
     }
 }
-
 
 /// Secret signing key that is split to provide side channel protection.
 ///
@@ -113,16 +119,18 @@ impl<E: EngineBLS> SecretKeyVT<E> {
 /// `self.key[0] * H(message) + self.key[1] * H(message) = (self.key[0] + self.key[1]) * H(message)`.
 /// In our case, we mutate the point being signed too by keeping
 /// an old point in both signed and unsigned forms, so our message
-/// point becomes `new_unsigned = H(message) - old_unsigned`, 
+/// point becomes `new_unsigned = H(message) - old_unsigned`,
 /// we compute `new_signed = self.key[0] * new_unsigned + self.key[1] * new_unsigned`,
 /// and our signature becomes `new_signed + old_signed`.
 /// We save the new signed and unsigned values as old ones, so that adversaries
 /// also cannot know the curves points being multiplied by scalars.
 /// In this, our `init_point_mutation` method signs some random point,
 /// so that even an adversary who tracks all signed messages cannot
-/// foresee the curve points being signed. 
+/// foresee the curve points being signed.
 ///
-#[cfg_attr(feature = "std", doc = r##"
+#[cfg_attr(
+    feature = "std",
+    doc = r##"
 /// We require mutable access to the secret key, but interior mutability
 /// can easily be employed, which might resemble:
 /// ```rust,no_run
@@ -138,7 +146,8 @@ impl<E: EngineBLS> SecretKeyVT<E> {
 /// If however `secret: Mutex<SecretKey>` or `secret: RwLock<SecretKey>`
 /// then one might avoid holding the write lock while signing, or even
 /// while sampling the random numbers by using other methods.
-"##)]
+"##
+)]
 ///
 /// Right now, we serialize using `SecretKey::into_vartime` and
 /// `SecretKeyVT::write`, so `secret.into_vartime().write(writer)?`.
@@ -170,12 +179,15 @@ impl<E: EngineBLS> Clone for SecretKey<E> {
     }
 }
 
-impl<E: EngineBLS> SecretKey<E> where E: EngineBLS {
+impl<E: EngineBLS> SecretKey<E>
+where
+    E: EngineBLS,
+{
     /// Generate a secret key that is already split for side channel protection,
     /// but does not apply signed point mutation.
     pub fn generate_dirty<R: Rng>(mut rng: R) -> Self {
         SecretKey {
-            key: [ E::generate(&mut rng), E::generate(&mut rng) ],
+            key: [E::generate(&mut rng), E::generate(&mut rng)],
             old_unsigned: E::SignatureGroup::zero(),
             old_signed: E::SignatureGroup::zero(),
         }
@@ -208,7 +220,7 @@ impl<E: EngineBLS> SecretKey<E> {
         self.old_signed += &s;
     }
 
-    /// Create a representative usable for operations lacking 
+    /// Create a representative usable for operations lacking
     /// side channel protections.  
     pub fn into_vartime(&self) -> SecretKeyVT<E> {
         let mut secret = self.key[0].clone();
@@ -216,7 +228,7 @@ impl<E: EngineBLS> SecretKey<E> {
         SecretKeyVT(secret)
     }
 
-    /// Randomly adjust how we split our secret signing key. 
+    /// Randomly adjust how we split our secret signing key.
     //
     // An initial call to this function after deserialization or
     // `into_split_dirty` incurs a miniscule risk from side channel
@@ -235,7 +247,7 @@ impl<E: EngineBLS> SecretKey<E> {
     /// Avoid using directly without appropriate `replit` calls, but maybe
     /// useful in proof-of-concenpt code, as it does not require a mutable
     /// secret key.
-    pub fn sign_once(&mut self, message: Message) -> Signature<E> {
+    pub fn sign_once(&mut self, message: &Message) -> Signature<E> {
         let mut z = message.hash_to_signature_curve::<E>();
         z -= &self.old_unsigned;
         self.old_unsigned = z.clone();
@@ -247,12 +259,12 @@ impl<E: EngineBLS> SecretKey<E> {
         self.old_signed = z.clone();
         z += &old_signed;
         // s.normalize();   // VRFs are faster if we only normalize once, but no normalize method exists.
-        // E::SignatureGroup::batch_normalization(&mut [&mut s]);  
+        // E::SignatureGroup::batch_normalization(&mut [&mut s]);
         Signature(z)
     }
 
     /// Sign after respliting the secret key for side channel protections.
-    pub fn sign<R: Rng>(&mut self, message: Message, rng: R) -> Signature<E> {
+    pub fn sign<R: Rng>(&mut self, message: &Message, rng: R) -> Signature<E> {
         self.resplit(rng);
         self.sign_once(message)
     }
@@ -263,8 +275,8 @@ impl<E: EngineBLS> SecretKey<E> {
     /// this call should be rare.
     pub fn into_public(&self) -> PublicKey<E> {
         let generator = <E::PublicKeyGroup as CurveGroup>::Affine::generator();
-        let mut publickey =  generator * self.key[0];
-        publickey +=  generator.into_group() * self.key[1];
+        let mut publickey = generator * self.key[0];
+        publickey += generator.into_group() * self.key[1];
         PublicKey(publickey)
         // TODO str4d never decided on projective vs affine here, so benchmark this.
         /*
@@ -276,9 +288,7 @@ impl<E: EngineBLS> SecretKey<E> {
         PublicKey(x)
         */
     }
-
 }
-
 
 // ////////////// NON-SECRETS ////////////// //
 
@@ -294,36 +304,39 @@ impl<E: EngineBLS> Borrow<E::$wrapped> for $wrapper<E> {
 impl<E: EngineBLS> BorrowMut<E::$wrapped> for $wrapper<E> {
     borrow_mut(&self) -> &E::$wrapped { &self.$var }
 }
-    } 
+    }
 } // macro_rules!
 */
 
 #[macro_export]
 macro_rules! broken_derives {
     ($wrapper:tt) => {
+        impl<E: EngineBLS> Clone for $wrapper<E> {
+            fn clone(&self) -> Self {
+                $wrapper(self.0)
+            }
+        }
+        impl<E: EngineBLS> Copy for $wrapper<E> {}
 
-impl<E: EngineBLS> Clone for $wrapper<E> {
-    fn clone(&self) -> Self { $wrapper(self.0) }
-}
-impl<E: EngineBLS> Copy for $wrapper<E> { }
+        impl<E: EngineBLS> PartialEq<Self> for $wrapper<E> {
+            fn eq(&self, other: &Self) -> bool {
+                self.0.eq(&other.0)
+            }
+        }
 
-impl<E: EngineBLS>  PartialEq<Self> for $wrapper<E> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
-    }
-}
-
-impl <E: EngineBLS> Eq for $wrapper<E> {}
-
-    }
-}  // macro_rules!
+        impl<E: EngineBLS> Eq for $wrapper<E> {}
+    };
+} // macro_rules!
 
 // //////// END MACROS //////// //
 
 /// Implementing de/serialization for secret keypair
 /// Note that deriving serialization for secret is not sensible
 /// as you need to conver them to vartime form first
-impl<E> CanonicalSerialize for SecretKey<E> where E: EngineBLS {
+impl<E> CanonicalSerialize for SecretKey<E>
+where
+    E: EngineBLS,
+{
     #[inline]
     fn serialize_with_mode<W: Write>(
         &self,
@@ -362,72 +375,89 @@ impl<E> CanonicalSerialize for SecretKey<E> where E: EngineBLS {
     // }
 }
 
-impl<E> Valid for SecretKey<E> where E: EngineBLS { 
-	fn check(&self) -> Result<(), SerializationError> {
-		//TODO probabaly turn into vartime and check that because vartime impl valid
-		match (self.key[1].check(), self.key[2].check()) {
-			(Ok(()),Ok(())) => Ok(()),
-			_ => Err(SerializationError::InvalidData),
-		}
+impl<E> Valid for SecretKey<E>
+where
+    E: EngineBLS,
+{
+    fn check(&self) -> Result<(), SerializationError> {
+        //TODO probabaly turn into vartime and check that because vartime impl valid
+        match (self.key[1].check(), self.key[2].check()) {
+            (Ok(()), Ok(())) => Ok(()),
+            _ => Err(SerializationError::InvalidData),
         }
-    
+    }
 }
 
-impl<E> CanonicalDeserialize for SecretKey<E> where E: EngineBLS {
+impl<E> CanonicalDeserialize for SecretKey<E>
+where
+    E: EngineBLS,
+{
     fn deserialize_with_mode<R: Read>(
         reader: R,
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, SerializationError> {
-            let secret_key_vt = <SecretKeyVT::<E> as CanonicalDeserialize>::deserialize_with_mode(reader, compress, validate)?;
-	    Ok(secret_key_vt.into_split_dirty())
+        let secret_key_vt = <SecretKeyVT<E> as CanonicalDeserialize>::deserialize_with_mode(
+            reader, compress, validate,
+        )?;
+        Ok(secret_key_vt.into_split_dirty())
     }
 
     #[inline]
     fn deserialize_compressed<R: Read>(reader: R) -> Result<Self, SerializationError> {
-        let secret_key_vt = <SecretKeyVT::<E> as CanonicalDeserialize>::deserialize_compressed(reader)?;
+        let secret_key_vt =
+            <SecretKeyVT<E> as CanonicalDeserialize>::deserialize_compressed(reader)?;
         Ok(secret_key_vt.into_split_dirty())
     }
 
     #[inline]
     fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let secret_key_vt = <SecretKeyVT::<E> as CanonicalDeserialize>::deserialize_uncompressed(&mut reader)?;
+        let secret_key_vt =
+            <SecretKeyVT<E> as CanonicalDeserialize>::deserialize_uncompressed(&mut reader)?;
         Ok(secret_key_vt.into_split_dirty())
     }
 
     #[inline]
     fn deserialize_uncompressed_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
-        let secret_key_vt = <SecretKeyVT::<E> as CanonicalDeserialize>::deserialize_uncompressed_unchecked(reader)?;
+        let secret_key_vt =
+            <SecretKeyVT<E> as CanonicalDeserialize>::deserialize_uncompressed_unchecked(reader)?;
         Ok(secret_key_vt.into_split_dirty())
     }
-
 }
 
 //TODO: when const generic becomes stable we get the size from the trait and return
 //      constant size array so it can be implemented as follows
 // impl <E: EngineBLS> SerializableToBytes<{ E::SIGNATURE_SERIALIZED_SIZE }> for Signature<E> {}
 // impl <E: EngineBLS> SerializableToBytes<{ PublicKey::E::PUBLICKEY_SERIALIZED_SIZE }> for PublicKey<E>  {}
-impl <E: EngineBLS> SerializableToBytes for Signature<E> {const SERIALIZED_BYTES_SIZE : usize = E::SIGNATURE_SERIALIZED_SIZE;}
-impl <E: EngineBLS> SerializableToBytes for PublicKey<E>  {const SERIALIZED_BYTES_SIZE : usize  = E::PUBLICKEY_SERIALIZED_SIZE;}
-impl <E: EngineBLS> SerializableToBytes for SecretKeyVT<E>  {const SERIALIZED_BYTES_SIZE : usize = E::SECRET_KEY_SIZE;}
+impl<E: EngineBLS> SerializableToBytes for Signature<E> {
+    const SERIALIZED_BYTES_SIZE: usize = E::SIGNATURE_SERIALIZED_SIZE;
+}
+impl<E: EngineBLS> SerializableToBytes for PublicKey<E> {
+    const SERIALIZED_BYTES_SIZE: usize = E::PUBLICKEY_SERIALIZED_SIZE;
+}
+impl<E: EngineBLS> SerializableToBytes for SecretKeyVT<E> {
+    const SERIALIZED_BYTES_SIZE: usize = E::SECRET_KEY_SIZE;
+}
 
-impl <E: EngineBLS> SerializableToBytes for SecretKey<E>  {const SERIALIZED_BYTES_SIZE : usize = E::SECRET_KEY_SIZE;}
+impl<E: EngineBLS> SerializableToBytes for SecretKey<E> {
+    const SERIALIZED_BYTES_SIZE: usize = E::SECRET_KEY_SIZE;
+}
 
 /// because SecretKey is not canonically serializable and that we need to convert
 /// it to vartime first we need to manually re-implement this trait for secret keys
 //, CanonicalSerialize, CanonicalDeserialize)]
-/// Detached BLS Signature 
+/// Detached BLS Signature
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Signature<E: EngineBLS>(pub E::SignatureGroup);
 // TODO: Serialization
 
-broken_derives!(Signature);  // Actually the derive works for this one, not sure why.
+broken_derives!(Signature); // Actually the derive works for this one, not sure why.
 
 impl<E: EngineBLS> Signature<E> {
-    //const DESCRIPTION : &'static str = "A BLS signature"; 
+    //const DESCRIPTION : &'static str = "A BLS signature";
 
     /// Verify a single BLS signature
-    pub fn verify(&self, message: Message, publickey: &PublicKey<E>) -> bool {
+    pub fn verify(&self, message: &Message, publickey: &PublicKey<E>) -> bool {
         let publickey = E::prepare_public_key(publickey.0);
         // TODO: Bentchmark these two variants
         // Variant 1.  Do not batch any normalizations
@@ -439,7 +469,7 @@ impl<E: EngineBLS> Signature<E> {
         //   let message = s[0].into_affine().prepare();
         //   let signature = s[1].into_affine().prepare();
         // TODO: Compare benchmarks on variants
-        E::verify_prepared( signature,  &[(publickey,message)] )
+        E::verify_prepared(signature, &[(publickey, message)])
     }
 }
 
@@ -459,8 +489,8 @@ broken_derives!(PublicKey);
 
 impl<E: EngineBLS> PublicKey<E> {
     //const DESCRIPTION : &'static str = "A BLS signature";
-    pub fn verify(&self, message: Message, signature: &Signature<E>) -> bool {
-        signature.verify(message,self)
+    pub fn verify(&self, message: &Message, signature: &Signature<E>) -> bool {
+        signature.verify(&message, self)
     }
 }
 
@@ -477,10 +507,12 @@ pub struct KeypairVT<E: EngineBLS> {
 }
 
 impl<E: EngineBLS> Clone for KeypairVT<E> {
-    fn clone(&self) -> Self { KeypairVT {
-        secret: self.secret.clone(),
-        public: self.public.clone(),
-    } }
+    fn clone(&self) -> Self {
+        KeypairVT {
+            secret: self.secret.clone(),
+            public: self.public.clone(),
+        }
+    }
 }
 
 // TODO: Serialization
@@ -502,15 +534,15 @@ impl<E: EngineBLS> KeypairVT<E> {
     }
 
     /// Sign a message creating a `SignedMessage` using a user supplied CSPRNG for the key splitting.
-    pub fn sign(&self, message: Message) -> Signature<E> {
+    pub fn sign(&self, message: &Message) -> Signature<E> {
         self.secret.sign(message)
     }
-    
+
     /// Sign a message creating a `SignedMessage` using a user supplied CSPRNG for the key splitting.
-    pub fn signed_message(&self, message: Message) -> SignedMessage<E> {
-        let signature = self.secret.sign(message);  
+    pub fn signed_message(&self, message: &Message) -> SignedMessage<E> {
+        let signature = self.secret.sign(&message);
         SignedMessage {
-            message,
+            message: message.clone(),
             publickey: self.public.clone(),
             signature,
         }
@@ -530,10 +562,12 @@ pub struct Keypair<E: EngineBLS> {
 }
 
 impl<E: EngineBLS> Clone for Keypair<E> {
-    fn clone(&self) -> Self { Keypair {
-        secret: self.secret.clone(),
-        public: self.public.clone(),
-    } }
+    fn clone(&self) -> Self {
+        Keypair {
+            secret: self.secret.clone(),
+            public: self.public.clone(),
+        }
+    }
 }
 
 // TODO: Serialization
@@ -547,7 +581,7 @@ impl<E: EngineBLS> Keypair<E> {
 }
 
 impl<E: EngineBLS> Keypair<E> {
-    /// Create a representative usable for operations lacking 
+    /// Create a representative usable for operations lacking
     /// side channel protections.  
     pub fn into_vartime(&self) -> KeypairVT<E> {
         let secret = self.secret.into_vartime();
@@ -556,40 +590,47 @@ impl<E: EngineBLS> Keypair<E> {
     }
 
     /// Sign a message creating a `Signature` using a user supplied CSPRNG for the key splitting.
-    pub fn sign_with_rng<R: Rng>(&mut self, message: Message, rng: R) -> Signature<E> {
-        self.secret.sign(message,rng)
+    pub fn sign_with_rng<R: Rng>(&mut self, message: &Message, rng: R) -> Signature<E> {
+        self.secret.sign(&message, rng)
     }
 
     /// Sign a message using a Seedabale RNG created from user supplied seed
-    pub fn sign_with_random_seed(&mut self, message: Message, seed: [u8; 32]) -> Signature<E> {
+    pub fn sign_with_random_seed(&mut self, message: &Message, seed: [u8; 32]) -> Signature<E> {
         self.sign_with_rng::<StdRng>(message, SeedableRng::from_seed(seed))
     }
 
     /// Sign a message using a Seedabale RNG created from a seed derived from the message and key
-    pub fn sign(&mut self, message: Message) -> Signature<E> {
-	let mut serialized_part1 = [0u8; 32];
-        let mut serialized_part2 = [0u8; 32]; 
-        self.secret.key[0].serialize_compressed(&mut serialized_part1[..]).unwrap();
-        self.secret.key[1].serialize_compressed(&mut serialized_part2[..]).unwrap();
-        
-        let seed_digest  = Sha256::new().chain_update(serialized_part1).chain_update(serialized_part2).chain_update(message.0);
+    pub fn sign(&mut self, message: &Message) -> Signature<E> {
+        let mut serialized_part1 = [0u8; 32];
+        let mut serialized_part2 = [0u8; 32];
+        self.secret.key[0]
+            .serialize_compressed(&mut serialized_part1[..])
+            .unwrap();
+        self.secret.key[1]
+            .serialize_compressed(&mut serialized_part2[..])
+            .unwrap();
 
-        let seed : [u8; 32] = seed_digest.finalize().into();
+        let seed_digest = Sha256::new()
+            .chain_update(serialized_part1)
+            .chain_update(serialized_part2)
+            .chain_update(message.0);
+
+        let seed: [u8; 32] = seed_digest.finalize().into();
 
         self.sign_with_rng::<StdRng>(message, SeedableRng::from_seed(seed))
     }
-  
+
     #[cfg(feature = "std")]
     /// Sign a message creating a `Signature` using the default `ThreadRng`.
-    pub fn sign_thread_rng(&mut self, message: Message) -> Signature<E> {
-        	self.sign_with_rng(message,thread_rng())
+    pub fn sign_thread_rng(&mut self, message: &Message) -> Signature<E> {
+        self.sign_with_rng(message, thread_rng())
     }
-    
+
     /// Create a `SignedMessage` using the default `ThreadRng`.
-    pub fn signed_message(&mut self, message: Message) -> SignedMessage<E> {
-	let signature = self.sign(message);
+    pub fn signed_message(&mut self, message: &Message) -> SignedMessage<E> {
+        let signature = self.sign(&message);
         SignedMessage {
-            message,
+            message: message.clone(),
             publickey: self.public,
             signature,
         }
@@ -597,9 +638,9 @@ impl<E: EngineBLS> Keypair<E> {
 }
 
 /// Message with attached BLS signature
-/// 
-/// 
-#[derive(Debug,Clone)]
+///
+///
+#[derive(Debug, Clone)]
 pub struct SignedMessage<E: EngineBLS> {
     pub message: Message,
     pub publickey: PublicKey<E>,
@@ -610,17 +651,17 @@ pub struct SignedMessage<E: EngineBLS> {
 // borrow_wrapper!(Signature,SignatureGroup,signature);
 // borrow_wrapper!(PublicKey,PublicKeyGroup,publickey);
 
-impl<E: EngineBLS>  PartialEq<Self> for SignedMessage<E> {
+impl<E: EngineBLS> PartialEq<Self> for SignedMessage<E> {
     fn eq(&self, other: &Self) -> bool {
         self.message.eq(&other.message)
-        && self.publickey.eq(&other.publickey)
-        && self.signature.eq(&other.signature)
+            && self.publickey.eq(&other.publickey)
+            && self.signature.eq(&other.signature)
     }
 }
 
-impl <E: EngineBLS> Eq for SignedMessage<E> {}
+impl<E: EngineBLS> Eq for SignedMessage<E> {}
 
-impl<'a,E: EngineBLS> Signed for &'a SignedMessage<E> {
+impl<'a, E: EngineBLS> Signed for &'a SignedMessage<E> {
     type E = E;
 
     type M = Message;
@@ -629,13 +670,15 @@ impl<'a,E: EngineBLS> Signed for &'a SignedMessage<E> {
     type PKnM = ::core::iter::Once<(Message, PublicKey<E>)>;
 
     fn messages_and_publickeys(self) -> Self::PKnM {
-        once((self.message.clone(), self.publickey))    // TODO:  Avoid clone
+        once((self.message.clone(), self.publickey)) // TODO:  Avoid clone
     }
 
-    fn signature(&self) -> Signature<E> { self.signature }
+    fn signature(&self) -> Signature<E> {
+        self.signature
+    }
 
     fn verify(self) -> bool {
-        self.signature.verify(self.message, &self.publickey)
+        self.signature.verify(&self.message, &self.publickey)
     }
 }
 
@@ -644,7 +687,8 @@ impl<E: EngineBLS> SignedMessage<E> {
     pub fn verify_slow(&self) -> bool {
         let g1_one = <E::PublicKeyGroup as CurveGroup>::Affine::generator();
         let message = self.message.hash_to_signature_curve::<E>().into_affine();
-        E::pairing(g1_one, self.signature.0.into_affine()) == E::pairing(self.publickey.0.into_affine(), message)
+        E::pairing(g1_one, self.signature.0.into_affine())
+            == E::pairing(self.publickey.0.into_affine(), message)
     }
 
     /// Hash output from a BLS signature regarded as a VRF.
@@ -663,9 +707,11 @@ impl<E: EngineBLS> SignedMessage<E> {
         h.update(b"out");
         let affine_signature = self.signature.0.into_affine();
         let mut serialized_signature = vec![0; affine_signature.uncompressed_size()];
-        affine_signature.serialize_uncompressed(&mut serialized_signature[..]).unwrap();
+        affine_signature
+            .serialize_uncompressed(&mut serialized_signature[..])
+            .unwrap();
 
-        h.update(& serialized_signature);
+        h.update(&serialized_signature);
     }
 
     /// Raw bytes output from a BLS signature regarded as a VRF.
@@ -705,144 +751,209 @@ impl<E: EngineBLS> SignedMessage<E> {
     /// ["Ouroboros Praos: An adaptively-secure, semi-synchronous proof-of-stake blockchain"](https://eprint.iacr.org/2017/573.pdf)
     /// by Bernardo David, Peter Gazi, Aggelos Kiayias, and Alexander Russell.
     pub fn make_chacharng(&self, context: &[u8]) -> ChaCha8Rng {
-        let bytes = self.make_bytes::<[u8;32]>(context);
+        let bytes = self.make_bytes::<[u8; 32]>(context);
         ChaCha8Rng::from_seed(bytes)
     }
 }
 
-
-#[cfg(all(test, feature="std"))]
+#[cfg(all(test, feature = "std"))]
 mod tests {
-    use ark_ec::pairing::Pairing as PairingEngine;
-    use ark_bls12_381::Bls12_381;
     use ark_bls12_377::Bls12_377;
+    use ark_bls12_381::Bls12_381;
     use ark_ec::bls12::Bls12Config;
     use ark_ec::hashing::curve_maps::wb::{WBConfig, WBMap};
-    use ark_ec::hashing::map_to_curve_hasher::{MapToCurve};
-    
+    use ark_ec::hashing::map_to_curve_hasher::MapToCurve;
+    use ark_ec::pairing::Pairing as PairingEngine;
+
     use super::*;
-    use crate::{ProofOfPossessionGenerator, ProofOfPossessionVerifier};
-    use crate::chaum_pedersen_signature::{ChaumPedersenSigner, ChaumPedersenVerifier};
-    use crate::{UsualBLS, TinyBLS};
-    
-    use hex_literal::hex;
+    use crate::{TinyBLS, UsualBLS};
+
     use core::convert::TryInto;
-    
-    fn bls_engine_serialization_test<EB: EngineBLS<Engine = E>, E: PairingEngine, P: Bls12Config>(x: SignedMessage<EB>) -> SignedMessage<EB> where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2> 
+    use hex_literal::hex;
+
+    fn bls_engine_serialization_test<EB: EngineBLS<Engine = E>, E: PairingEngine, P: Bls12Config>(
+        x: SignedMessage<EB>,
+    ) -> SignedMessage<EB>
+    where
+        <P as Bls12Config>::G2Config: WBConfig,
+        WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2>,
     {
-        let SignedMessage { message, publickey, signature } = x;
+        let SignedMessage {
+            message,
+            publickey,
+            signature,
+        } = x;
 
         let publickey = PublicKey::<EB>::from_bytes(&publickey.to_bytes()).unwrap();
         let signature = Signature::<EB>::from_bytes(&signature.to_bytes()).unwrap();
-        
-        SignedMessage { message, publickey, signature }
-        
+
+        SignedMessage {
+            message,
+            publickey,
+            signature,
+        }
     }
 
     /// generates a random secret key sign a message and convert the
     /// key to bytes then reconvert it to key and derive its public key
     /// And check if the signature still verifies    
-    fn test_serialize_deserialize_production_secret_key<E: PairingEngine, P: Bls12Config>() where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2> {
-        let mut keypair  = Keypair::<UsualBLS<E,P>>::generate(thread_rng());
+    fn test_serialize_deserialize_production_secret_key<E: PairingEngine, P: Bls12Config>()
+    where
+        <P as Bls12Config>::G2Config: WBConfig,
+        WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2>,
+    {
+        let mut keypair = Keypair::<UsualBLS<E, P>>::generate(thread_rng());
         let serialized_secret_key = keypair.secret.to_bytes();
-        println!("secret key serialize size: {}, secret key first scaler serialize size {}", keypair.secret.uncompressed_size(), keypair.secret.key[0].uncompressed_size());
+        println!(
+            "secret key serialize size: {}, secret key first scaler serialize size {}",
+            keypair.secret.uncompressed_size(),
+            keypair.secret.key[0].uncompressed_size()
+        );
 
-        let good_message = Message::new(b"ctx",b"test message");
+        let good_message = Message::new(b"ctx", b"test message");
 
-        let sig = keypair.sign(good_message);
+        let sig = keypair.sign(&good_message);
 
-        let deserialized_secret_key = SecretKey::<UsualBLS<E,P>>::from_bytes(&serialized_secret_key).unwrap();
-        let reconstructed_public_key = deserialized_secret_key.into_public();        
-        assert!( sig.verify(good_message,&reconstructed_public_key) );        
+        let deserialized_secret_key =
+            SecretKey::<UsualBLS<E, P>>::from_bytes(&serialized_secret_key).unwrap();
+        let reconstructed_public_key = deserialized_secret_key.into_public();
+        assert!(sig.verify(&good_message, &reconstructed_public_key));
     }
 
-    fn test_deserialize_random_value_as_secret_key_fails<E: PairingEngine, P: Bls12Config>(random_seed: &[u8]) where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2> {
-
-        match SecretKey::<UsualBLS<E,P>>::from_bytes(random_seed.try_into().expect("the size of the seed be 32 Bytes.")) {
-            Ok(_) => assert!(false, "random seed should not be canonically deserializable to a secret key."),
+    fn test_deserialize_random_value_as_secret_key_fails<E: PairingEngine, P: Bls12Config>(
+        random_seed: &[u8],
+    ) where
+        <P as Bls12Config>::G2Config: WBConfig,
+        WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2>,
+    {
+        match SecretKey::<UsualBLS<E, P>>::from_bytes(
+            random_seed
+                .try_into()
+                .expect("the size of the seed be 32 Bytes."),
+        ) {
+            Ok(_) => assert!(
+                false,
+                "random seed should not be canonically deserializable to a secret key."
+            ),
             Err(SerializationError::InvalidData) => (),
-            _ => assert!(false, "unexpected deserialization error.")
+            _ => assert!(false, "unexpected deserialization error."),
         }
-
     }
-    
-    // fn test_public_key_and_message_serialization<E: PairingEngine, P: Bls12Config>(x: SignedMessage<EB>)-> SignedMessage<E> where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2> {	
+
+    // fn test_public_key_and_message_serialization<E: PairingEngine, P: Bls12Config>(x: SignedMessage<EB>)-> SignedMessage<E> where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2> {
     //     let SignedMessage { message, publickey, signature } = x;
-    //     let publickey = PublicKey::<E>::from_bytes(publickey.to_bytes()).unwrap();        
+    //     let publickey = PublicKey::<E>::from_bytes(publickey.to_bytes()).unwrap();
     //     let signature = Signature::<E>::from_bytes(signature.to_bytes()).unwrap();
-    //     assert!(SignedMessage { message, publickey, signature } == x);	
+    //     assert!(SignedMessage { message, publickey, signature } == x);
     // }
-    
-    fn test_single_bls_message<E: PairingEngine, P: Bls12Config>() where <P as Bls12Config>::G2Config: WBConfig, WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2> {
 
-        let good = Message::new(b"ctx",b"test message");
+    fn test_single_bls_message<E: PairingEngine, P: Bls12Config>()
+    where
+        <P as Bls12Config>::G2Config: WBConfig,
+        WBMap<<P as Bls12Config>::G2Config>: MapToCurve<<E as PairingEngine>::G2>,
+    {
+        let good = Message::new(b"ctx", b"test message");
 
-        let mut keypair  = Keypair::<UsualBLS<E,P>>::generate(thread_rng());
-        let good_sig0 = keypair.signed_message(good);
-        let good_sig = bls_engine_serialization_test::<UsualBLS<E,P>, E, P>(good_sig0);
+        let mut keypair = Keypair::<UsualBLS<E, P>>::generate(thread_rng());
+        let good_sig0 = keypair.signed_message(&good);
+        let good_sig = bls_engine_serialization_test::<UsualBLS<E, P>, E, P>(good_sig0);
         assert!(good_sig.verify_slow());
 
         let keypair_vt = keypair.into_vartime();
-        assert!( keypair_vt.secret.0 == keypair_vt.into_split(thread_rng()).into_vartime().secret.0 );
-        assert!( good_sig == keypair.signed_message(good) );
-        assert!( good_sig == keypair_vt.signed_message(good) );
+        assert!(keypair_vt.secret.0 == keypair_vt.into_split(thread_rng()).into_vartime().secret.0);
+        assert!(good_sig == keypair.signed_message(&good));
+        assert!(good_sig == keypair_vt.signed_message(&good));
 
-        let bad = Message::new(b"ctx",b"wrong message");
-        let bad_sig0 = keypair.signed_message(bad);
-	    let bad_sig = bls_engine_serialization_test::<UsualBLS<E,P>, E, P>(bad_sig0);
-        assert!( bad_sig == keypair.into_vartime().signed_message(bad) );
+        let bad = Message::new(b"ctx", b"wrong message");
+        let bad_sig0 = keypair.signed_message(&bad);
+        let bad_sig = bls_engine_serialization_test::<UsualBLS<E, P>, E, P>(bad_sig0);
+        assert!(bad_sig == keypair.into_vartime().signed_message(&bad));
 
-        assert!( bad_sig.verify() );
+        assert!(bad_sig.verify());
 
-        let another = Message::new(b"ctx",b"another message");
-        let another_sig = keypair.signed_message(another);
-        assert!( another_sig == keypair.into_vartime().signed_message(another) );
-        assert!( another_sig.verify() );
-	
-        assert!(keypair.public.verify(good, &good_sig.signature),
-                "Verification of a valid signature failed!");
-	
-	    assert!(good != bad, "good == bad");
-	    assert!(good_sig.signature != bad_sig.signature, "good sig == bad sig");
-	
-        assert!(!keypair.public.verify(good, &bad_sig.signature),
-                "Verification of a signature on a different message passed!");
-        assert!(!keypair.public.verify(bad, &good_sig.signature),
-                "Verification of a signature on a different message passed!");
-        assert!(!keypair.public.verify(Message::new(b"other",b"test message"), &good_sig.signature),
-                "Verification of a signature on a different message passed!");
+        let another = Message::new(b"ctx", b"another message");
+        let another_sig = keypair.signed_message(&another);
+        assert!(another_sig == keypair.into_vartime().signed_message(&another));
+        assert!(another_sig.verify());
+
+        assert!(
+            keypair.public.verify(&good, &good_sig.signature),
+            "Verification of a valid signature failed!"
+        );
+
+        assert!(good != bad, "good == bad");
+        assert!(
+            good_sig.signature != bad_sig.signature,
+            "good sig == bad sig"
+        );
+
+        assert!(
+            !keypair.public.verify(&good, &bad_sig.signature),
+            "Verification of a signature on a different message passed!"
+        );
+        assert!(
+            !keypair.public.verify(&bad, &good_sig.signature),
+            "Verification of a signature on a different message passed!"
+        );
+        assert!(
+            !keypair.public.verify(
+                &Message::new(b"other", b"test message"),
+                &good_sig.signature
+            ),
+            "Verification of a signature on a different message passed!"
+        );
     }
 
-	#[test]
-	fn  zbls_engine_bytes_test() {
-	    let mut keypair  = Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-            let good_sig0 = keypair.signed_message(Message::new(b"ctx",b"test message"));
+    #[test]
+    fn zbls_engine_bytes_test() {
+        let mut keypair =
+            Keypair::<UsualBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig0 = keypair.signed_message(&Message::new(b"ctx", b"test message"));
 
-	    bls_engine_serialization_test::<UsualBLS<Bls12_381, ark_bls12_381::Config>, Bls12_381, ark_bls12_381::Config>(good_sig0);
+        bls_engine_serialization_test::<
+            UsualBLS<Bls12_381, ark_bls12_381::Config>,
+            Bls12_381,
+            ark_bls12_381::Config,
+        >(good_sig0);
     }
-	 #[test]
-	 fn bls377_engine_bytes_test() {
-	    let mut keypair  = Keypair::<UsualBLS<Bls12_377, ark_bls12_377::Config>>::generate(thread_rng());
-            let good_sig0 = keypair.signed_message(Message::new(b"ctx",b"test message"));
+    #[test]
+    fn bls377_engine_bytes_test() {
+        let mut keypair =
+            Keypair::<UsualBLS<Bls12_377, ark_bls12_377::Config>>::generate(thread_rng());
+        let good_sig0 = keypair.signed_message(&Message::new(b"ctx", b"test message"));
 
-	    bls_engine_serialization_test::<UsualBLS<Bls12_377, ark_bls12_377::Config>, Bls12_377, ark_bls12_377::Config>(good_sig0);
-	 }
+        bls_engine_serialization_test::<
+            UsualBLS<Bls12_377, ark_bls12_377::Config>,
+            Bls12_377,
+            ark_bls12_377::Config,
+        >(good_sig0);
+    }
 
-    	 #[test]
-	 fn tiny_zbls_engine_bytes_test() {
-	    let mut keypair  = Keypair::<TinyBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
-            let good_sig0 = keypair.signed_message(Message::new(b"ctx",b"test message"));
+    #[test]
+    fn tiny_zbls_engine_bytes_test() {
+        let mut keypair =
+            Keypair::<TinyBLS<Bls12_381, ark_bls12_381::Config>>::generate(thread_rng());
+        let good_sig0 = keypair.signed_message(&Message::new(b"ctx", b"test message"));
 
-	    bls_engine_serialization_test::<TinyBLS<Bls12_381, ark_bls12_381::Config>, Bls12_381, ark_bls12_381::Config>(good_sig0);
-	 }
-    
-    	 #[test]
-	 fn tiny_bls377_engine_bytes_test() {
-	    let mut keypair  = Keypair::<TinyBLS<Bls12_377, ark_bls12_377::Config>>::generate(thread_rng());
-            let good_sig0 = keypair.signed_message(Message::new(b"ctx",b"test message"));
+        bls_engine_serialization_test::<
+            TinyBLS<Bls12_381, ark_bls12_381::Config>,
+            Bls12_381,
+            ark_bls12_381::Config,
+        >(good_sig0);
+    }
 
-	    bls_engine_serialization_test::<TinyBLS<Bls12_377, ark_bls12_377::Config>, Bls12_377, ark_bls12_377::Config>(good_sig0);
-	 }
+    #[test]
+    fn tiny_bls377_engine_bytes_test() {
+        let mut keypair =
+            Keypair::<TinyBLS<Bls12_377, ark_bls12_377::Config>>::generate(thread_rng());
+        let good_sig0 = keypair.signed_message(&Message::new(b"ctx", b"test message"));
+
+        bls_engine_serialization_test::<
+            TinyBLS<Bls12_377, ark_bls12_377::Config>,
+            Bls12_377,
+            ark_bls12_377::Config,
+        >(good_sig0);
+    }
 
     #[test]
     fn single_messages_zbls() {
@@ -851,7 +962,7 @@ mod tests {
 
     #[test]
     fn single_messages_bls377() {
-        test_single_bls_message::<Bls12_377,ark_bls12_377::Config>();
+        test_single_bls_message::<Bls12_377, ark_bls12_377::Config>();
     }
 
     #[test]
@@ -866,8 +977,9 @@ mod tests {
 
     #[test]
     fn test_deserialize_random_value_as_secret_key_fails_for_bls377() {
-        let random_seed  = hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
-        test_deserialize_random_value_as_secret_key_fails::<Bls12_377, ark_bls12_377::Config>(random_seed.as_slice());
+        let random_seed = hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+        test_deserialize_random_value_as_secret_key_fails::<Bls12_377, ark_bls12_377::Config>(
+            random_seed.as_slice(),
+        );
     }
-
 }

--- a/src/verifiers.rs
+++ b/src/verifiers.rs
@@ -1,25 +1,24 @@
 //! ## Algorithms for optimized verification of aggregate and batched BLS signatures.
 //!
 //!
-//! 
+//!
 
 use core::borrow::Borrow;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
-use ark_ec::{CurveGroup, AffineRepr};
-use ark_serialize::{CanonicalSerialize};
-use ark_ff::field_hashers::{DefaultFieldHasher,HashToField};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
+use ark_serialize::CanonicalSerialize;
 
 use alloc::{vec, vec::Vec};
 
-use digest::{Digest};
-use sha2::Sha256;    
-
+use digest::Digest;
+use sha2::Sha256;
 
 use super::*;
 
-// We define these convenience type alias here instead of engine.rs 
+// We define these convenience type alias here instead of engine.rs
 // because seemingly only verifier implementations really employ them.
 // And we `pub use engine::*` in lib.rs.
 
@@ -35,21 +34,20 @@ pub type SignatureProjective<E> = <E as EngineBLS>::SignatureGroup;
 /// Convenience type alias for affine form of `SignatureGroup`
 pub type SignatureAffine<E> = <<E as EngineBLS>::SignatureGroup as CurveGroup>::Affine;
 
-
 /// Simple unoptimized BLS signature verification.  Useful for testing.
 pub fn verify_unoptimized<S: Signed>(s: S) -> bool {
     let signature = S::E::prepare_signature(s.signature().0);
-    let prepared = s.messages_and_publickeys()
-        .map(|(message,public_key)| {
-            (S::E::prepare_public_key(public_key.borrow().0),
-             S::E::prepare_signature(message.borrow().hash_to_signature_curve::<S::E>()))
-        }).collect::<Vec<(_,_)>>();
-    S::E::verify_prepared(
-        signature,
-        prepared.iter()
-    )
+    let prepared = s
+        .messages_and_publickeys()
+        .map(|(message, public_key)| {
+            (
+                S::E::prepare_public_key(public_key.borrow().0),
+                S::E::prepare_signature(message.borrow().hash_to_signature_curve::<S::E>()),
+            )
+        })
+        .collect::<Vec<(_, _)>>();
+    S::E::verify_prepared(signature, prepared.iter())
 }
-
 
 /// Simple universal BLS signature verification
 ///
@@ -57,39 +55,50 @@ pub fn verify_unoptimized<S: Signed>(s: S) -> bool {
 /// securely by calling it only once and batch normalizing all
 /// points, as do most other verification routines here.
 /// We do no optimizations that reduce the number of pairings
-/// by combining repeated messages or signers. 
+/// by combining repeated messages or signers.
 pub fn verify_simple<S: Signed>(s: S) -> bool {
     let signature = s.signature().0;
     // We could write this more idiomatically using iterator adaptors,
     // and avoiding an unecessary allocation for publickeys, but only
     // by calling self.messages_and_publickeys() repeatedly.
     let itr = s.messages_and_publickeys();
-    let l = {  let (lower, upper) = itr.size_hint();  upper.unwrap_or(lower)  };
+    let l = {
+        let (lower, upper) = itr.size_hint();
+        upper.unwrap_or(lower)
+    };
     let mut gpk = Vec::with_capacity(l);
-    let mut gms = Vec::with_capacity(l+1);
-    for (message,publickey) in itr {
-        gpk.push( publickey.borrow().0.clone());
-        gms.push( message.borrow().hash_to_signature_curve::<S::E>() );
+    let mut gms = Vec::with_capacity(l + 1);
+    for (message, publickey) in itr {
+        gpk.push(publickey.borrow().0.clone());
+        gms.push(message.borrow().hash_to_signature_curve::<S::E>());
     }
     let gpk = <<S as Signed>::E as EngineBLS>::PublicKeyGroup::normalize_batch(gpk.as_mut_slice());
     gms.push(signature);
-    let mut gms = <<S as Signed>::E as EngineBLS>::SignatureGroup::normalize_batch(gms.as_mut_slice());
+    let mut gms =
+        <<S as Signed>::E as EngineBLS>::SignatureGroup::normalize_batch(gms.as_mut_slice());
     let signature = <<S as Signed>::E as EngineBLS>::prepare_signature(gms.pop().unwrap());
-    let prepared = gpk.iter().zip(gms)
-        .map(|(pk,m)| { (<<S as Signed>::E as EngineBLS>::prepare_public_key(*pk), <<S as Signed>::E as EngineBLS>::prepare_signature(m)) })
-        .collect::<Vec<(_,_)>>();
-    S::E::verify_prepared( signature, prepared.iter())
+    let prepared = gpk
+        .iter()
+        .zip(gms)
+        .map(|(pk, m)| {
+            (
+                <<S as Signed>::E as EngineBLS>::prepare_public_key(*pk),
+                <<S as Signed>::E as EngineBLS>::prepare_signature(m),
+            )
+        })
+        .collect::<Vec<(_, _)>>();
+    S::E::verify_prepared(signature, prepared.iter())
 }
 
 /// BLS signature verification optimized for all unique messages
 ///
 /// Assuming all messages are distinct, the minimum number of pairings
-/// is the number of unique signers, which we achieve here. 
+/// is the number of unique signers, which we achieve here.
 /// We do not verify message uniqueness here, but leave this to the
 /// aggregate signature type, like `DistinctMessages`.
 ///
 /// We merge any messages with identical signers and batch normalize
-/// message points and the signature itself. 
+/// message points and the signature itself.
 /// We optionally batch normalize the public keys in the event that
 /// they are provided by algerbaic operaations, but this sounds
 /// unlikely given our requirement that messages be distinct.
@@ -102,21 +111,27 @@ pub fn verify_with_distinct_messages<S: Signed>(signed: S, normalize_public_keys
     // mutability, maybe using `BorrowMut` support in
     // `batch_normalization`.
     let itr = signed.messages_and_publickeys();
-    let l = {  let (lower, upper) = itr.size_hint();  upper.unwrap_or(lower)  };
+    let l = {
+        let (lower, upper) = itr.size_hint();
+        upper.unwrap_or(lower)
+    };
     let mut publickeys = Vec::with_capacity(l);
-    let mut messages = Vec::with_capacity(l+1);
-    for (m,pk) in itr {
-        publickeys.push( pk.borrow().0.clone() );
-        messages.push( m.borrow().hash_to_signature_curve::<S::E>() );
+    let mut messages = Vec::with_capacity(l + 1);
+    for (m, pk) in itr {
+        publickeys.push(pk.borrow().0.clone());
+        messages.push(m.borrow().hash_to_signature_curve::<S::E>());
     }
     let mut affine_publickeys = if normalize_public_keys {
-         <<S as Signed>::E as EngineBLS>::PublicKeyGroup::normalize_batch(&publickeys)
+        <<S as Signed>::E as EngineBLS>::PublicKeyGroup::normalize_batch(&publickeys)
     } else {
-        publickeys.iter().map(|pk| pk.into_affine()).collect::<Vec<_>>()
+        publickeys
+            .iter()
+            .map(|pk| pk.into_affine())
+            .collect::<Vec<_>>()
     };
 
     // We next accumulate message points with the same signer.
-    // We could avoid the allocation here if we sorted both 
+    // We could avoid the allocation here if we sorted both
     // arrays in parallel.  This might mean (a) some sort function
     // using `ops::IndexMut` instead of slices, and (b) wrapper types
     // types to make tuples of slices satisfy `ops::IndexMut`.
@@ -124,18 +139,19 @@ pub fn verify_with_distinct_messages<S: Signed>(signed: S, normalize_public_keys
     // to avoid  struct H(E::PublicKeyGroup::Affine::Uncompressed);
     type AA<E> = (PublicKeyAffine<E>, SignatureProjective<E>);
     let mut pks_n_ms = HashMap::with_capacity(l);
-    for (pk,m) in affine_publickeys.drain(..)
-                            .zip(messages.drain(..)) 
-    {
-        let mut pk_uncompressed = vec![0;  pk.uncompressed_size()];        
+    for (pk, m) in affine_publickeys.drain(..).zip(messages.drain(..)) {
+        let mut pk_uncompressed = vec![0; pk.uncompressed_size()];
         pk.serialize_uncompressed(&mut pk_uncompressed[..]).unwrap();
-        pks_n_ms.entry(pk_uncompressed)
-            .and_modify(|(_pk0,m0):  &mut AA<S::E>| {*m0 += m;} )
-                .or_insert((pk,m));
+        pks_n_ms
+            .entry(pk_uncompressed)
+            .and_modify(|(_pk0, m0): &mut AA<S::E>| {
+                *m0 += m;
+            })
+            .or_insert((pk, m));
     }
 
     let mut publickeys = Vec::with_capacity(l);
-    for (_,(pk,m)) in pks_n_ms.drain() {
+    for (_, (pk, m)) in pks_n_ms.drain() {
         messages.push(m);
         publickeys.push(pk.clone());
     }
@@ -143,55 +159,76 @@ pub fn verify_with_distinct_messages<S: Signed>(signed: S, normalize_public_keys
     // We finally normalize the messages and signature
 
     messages.push(signature);
-    let mut affine_messages = <<S as Signed>::E as EngineBLS>::SignatureGroup::normalize_batch(messages.as_mut_slice());
-    let signature = <<S as Signed>::E as EngineBLS>::prepare_signature(affine_messages.pop().unwrap());
+    let mut affine_messages =
+        <<S as Signed>::E as EngineBLS>::SignatureGroup::normalize_batch(messages.as_mut_slice());
+    let signature =
+        <<S as Signed>::E as EngineBLS>::prepare_signature(affine_messages.pop().unwrap());
     // TODO: Assess if we could cache normalized message hashes anyplace
     // using interior mutability, but probably this does not work well
     // with ur optimization of collecting messages with thesame signer.
 
     // And verify the aggregate signature.
-    let  prepared = publickeys.iter().zip(messages).map(|(pk,m)| { (<<S as Signed>::E as EngineBLS>::prepare_public_key(*pk), <<S as Signed>::E as EngineBLS>::prepare_signature(m)) })
-        .collect::<Vec<(_,_)>>();
+    let prepared = publickeys
+        .iter()
+        .zip(messages)
+        .map(|(pk, m)| {
+            (
+                <<S as Signed>::E as EngineBLS>::prepare_public_key(*pk),
+                <<S as Signed>::E as EngineBLS>::prepare_signature(m),
+            )
+        })
+        .collect::<Vec<(_, _)>>();
 
-    S::E::verify_prepared( signature, prepared.iter() )
+    S::E::verify_prepared(signature, prepared.iter())
 
     //let prepared = publickeys.iter().zip(&messages);
     //S::E::verify_prepared( &signature, prepared )
-
 }
 
 /// BLS signature verification optimized for all unique messages
 ///
 /// Assuming all messages are distinct, the minimum number of pairings
-/// is the number of unique signers, which we achieve here. 
+/// is the number of unique signers, which we achieve here.
 /// We do not verify message uniqueness here, but leave this to the
 /// aggregate signature type, like `DistinctMessages`.
 ///
 /// We merge any messages with identical signers and batch normalize
-/// message points and the signature itself. 
+/// message points and the signature itself.
 /// We optionally batch normalize the public keys in the event that
 /// they are provided by algerbaic operaations, but this sounds
 /// unlikely given our requirement that messages be distinct.
 #[cfg(feature = "std")]
-pub fn verify_using_aggregated_auxiliary_public_keys<E: EngineBLS>(signed: &pop::SignatureAggregatorAssumingPoP<E>, normalize_public_keys: bool, aggregated_aux_pub_key: <E as EngineBLS>::SignatureGroup) -> bool {
+pub fn verify_using_aggregated_auxiliary_public_keys<E: EngineBLS>(
+    signed: &pop::SignatureAggregatorAssumingPoP<E>,
+    normalize_public_keys: bool,
+    aggregated_aux_pub_key: <E as EngineBLS>::SignatureGroup,
+) -> bool {
     let signature = Signed::signature(&signed).0;
 
-    let mut signature_as_bytes = vec![0;  signature.compressed_size()];
-    signature.serialize_compressed(&mut signature_as_bytes[..]).expect("compressed size has been alocated");
+    let mut signature_as_bytes = vec![0; signature.compressed_size()];
+    signature
+        .serialize_compressed(&mut signature_as_bytes[..])
+        .expect("compressed size has been alocated");
 
     let itr = signed.messages_and_publickeys();
-    let l = {  let (lower, upper) = itr.size_hint();  upper.unwrap_or(lower)  };
-    let (_, first_public_key) =
-        match signed.messages_and_publickeys().next() {
-            Some((first_message, first_public_key)) => (first_message, first_public_key),
-            None => return false,
-        };
+    let l = {
+        let (lower, upper) = itr.size_hint();
+        upper.unwrap_or(lower)
+    };
+    let (_, first_public_key) = match signed.messages_and_publickeys().next() {
+        Some((first_message, first_public_key)) => (first_message, first_public_key),
+        None => return false,
+    };
 
-    let mut first_public_key_as_bytes = vec![0;  first_public_key.compressed_size()];
-    first_public_key.serialize_compressed(&mut first_public_key_as_bytes[..]).expect("compressed size has been alocated");
+    let mut first_public_key_as_bytes = vec![0; first_public_key.compressed_size()];
+    first_public_key
+        .serialize_compressed(&mut first_public_key_as_bytes[..])
+        .expect("compressed size has been alocated");
 
-    let mut aggregated_aux_pub_key_as_bytes = vec![0;  aggregated_aux_pub_key.compressed_size()];
-    aggregated_aux_pub_key.serialize_compressed(&mut aggregated_aux_pub_key_as_bytes[..]).expect("compressed size has been alocated");
+    let mut aggregated_aux_pub_key_as_bytes = vec![0; aggregated_aux_pub_key.compressed_size()];
+    aggregated_aux_pub_key
+        .serialize_compressed(&mut aggregated_aux_pub_key_as_bytes[..])
+        .expect("compressed size has been alocated");
 
     // We first hash the messages to the signature curve and
     // normalize the public keys to operate on them as bytes.
@@ -202,27 +239,39 @@ pub fn verify_using_aggregated_auxiliary_public_keys<E: EngineBLS>(signed: &pop:
     // deterministic randomness for adding aggregated auxiliary pub keys
     //TODO you can't just assume that there is one pubickey you need to stop if they were more or aggregate them
 
-    let pseudo_random_scalar_seed : [u8; 32] = Sha256::new().chain_update(signature_as_bytes).chain_update(first_public_key_as_bytes).chain_update(aggregated_aux_pub_key_as_bytes).finalize().into();
+    let pseudo_random_scalar_seed: [u8; 32] = Sha256::new()
+        .chain_update(signature_as_bytes)
+        .chain_update(first_public_key_as_bytes)
+        .chain_update(aggregated_aux_pub_key_as_bytes)
+        .finalize()
+        .into();
     let hasher = <DefaultFieldHasher<Sha256> as HashToField<E::Scalar>>::new(&[]);
-    let pseudo_random_scalar : E::Scalar = hasher.hash_to_field(&pseudo_random_scalar_seed[..],1)[0];
+    let pseudo_random_scalar: E::Scalar =
+        hasher.hash_to_field(&pseudo_random_scalar_seed[..], 1)[0];
 
     let signature = signature + aggregated_aux_pub_key * pseudo_random_scalar;
 
     let mut publickeys = Vec::with_capacity(l);
-    let mut messages = Vec::with_capacity(l+1);
-    for (m,pk) in itr {
-        publickeys.push( pk.borrow().0.clone() );
-        messages.push( m.borrow().hash_to_signature_curve::<E>() + E::SignatureGroupAffine::generator() * pseudo_random_scalar);
+    let mut messages = Vec::with_capacity(l + 1);
+    for (m, pk) in itr {
+        publickeys.push(pk.borrow().0.clone());
+        messages.push(
+            m.borrow().hash_to_signature_curve::<E>()
+                + E::SignatureGroupAffine::generator() * pseudo_random_scalar,
+        );
     }
-    
+
     let mut affine_publickeys = if normalize_public_keys {
-         <E as EngineBLS>::PublicKeyGroup::normalize_batch(&publickeys)
+        <E as EngineBLS>::PublicKeyGroup::normalize_batch(&publickeys)
     } else {
-        publickeys.iter().map(|pk| pk.into_affine()).collect::<Vec<_>>()
+        publickeys
+            .iter()
+            .map(|pk| pk.into_affine())
+            .collect::<Vec<_>>()
     };
 
     // We next accumulate message points with the same signer.
-    // We could avoid the allocation here if we sorted both 
+    // We could avoid the allocation here if we sorted both
     // arrays in parallel.  This might mean (a) some sort function
     // using `ops::IndexMut` instead of slices, and (b) wrapper types
     // types to make tuples of slices satisfy `ops::IndexMut`.
@@ -230,18 +279,19 @@ pub fn verify_using_aggregated_auxiliary_public_keys<E: EngineBLS>(signed: &pop:
     // to avoid  struct H(E::PublicKeyGroup::Affine::Uncompressed);
     type AA<E> = (PublicKeyAffine<E>, SignatureProjective<E>);
     let mut pks_n_ms = HashMap::with_capacity(l);
-    for (pk,m) in affine_publickeys.drain(..)
-                            .zip(messages.drain(..)) 
-    {
-        let mut pk_uncompressed = vec![0;  pk.uncompressed_size()];        
+    for (pk, m) in affine_publickeys.drain(..).zip(messages.drain(..)) {
+        let mut pk_uncompressed = vec![0; pk.uncompressed_size()];
         pk.serialize_uncompressed(&mut pk_uncompressed[..]).unwrap();
-        pks_n_ms.entry(pk_uncompressed)
-            .and_modify(|(_pk0,m0):  &mut AA<E>| {*m0 += m;} )
-                .or_insert((pk,m));
+        pks_n_ms
+            .entry(pk_uncompressed)
+            .and_modify(|(_pk0, m0): &mut AA<E>| {
+                *m0 += m;
+            })
+            .or_insert((pk, m));
     }
 
     let mut publickeys = Vec::with_capacity(l);
-    for (_,(pk,m)) in pks_n_ms.drain() {
+    for (_, (pk, m)) in pks_n_ms.drain() {
         messages.push(m);
         publickeys.push(pk.clone());
     }
@@ -249,21 +299,29 @@ pub fn verify_using_aggregated_auxiliary_public_keys<E: EngineBLS>(signed: &pop:
     // We finally normalize the messages and signature
 
     messages.push(signature);
-    let mut affine_messages = <E as EngineBLS>::SignatureGroup::normalize_batch(messages.as_mut_slice());
+    let mut affine_messages =
+        <E as EngineBLS>::SignatureGroup::normalize_batch(messages.as_mut_slice());
     let signature = <E as EngineBLS>::prepare_signature(affine_messages.pop().unwrap());
     // TODO: Assess if we could cache normalized message hashes anyplace
     // using interior mutability, but probably this does not work well
     // with ur optimization of collecting messages with thesame signer.
 
     // And verify the aggregate signature.
-    let  prepared = publickeys.iter().zip(messages).map(|(pk,m)| { (<E as EngineBLS>::prepare_public_key(*pk), <E as EngineBLS>::prepare_signature(m)) })
-        .collect::<Vec<(_,_)>>();
+    let prepared = publickeys
+        .iter()
+        .zip(messages)
+        .map(|(pk, m)| {
+            (
+                <E as EngineBLS>::prepare_public_key(*pk),
+                <E as EngineBLS>::prepare_signature(m),
+            )
+        })
+        .collect::<Vec<(_, _)>>();
 
-    E::verify_prepared( signature, prepared.iter() )
+    E::verify_prepared(signature, prepared.iter())
 
     //let prepared = publickeys.iter().zip(&messages);
     //S::E::verify_prepared( &signature, prepared )
-
 }
 
 /*
@@ -277,7 +335,7 @@ pub fn verify_using_aggregated_auxiliary_public_keys<E: EngineBLS>(signed: &pop:
 ///
 /// We expect this to improve performance dramatically when both
 /// signers and messages are repeated enough, simpler strategies
-/// work as well or better when say messages are distinct. 
+/// work as well or better when say messages are distinct.
 ///
 /// Explination:
 ///
@@ -299,14 +357,14 @@ pub fn verify_using_aggregated_auxiliary_public_keys<E: EngineBLS>(signed: &pop:
 /// so we may do row or column swaps and row or column addition
 /// operations with small scalars, but not lone row or column scalar
 /// multiplication because these always involve divisions, which
-/// produces large curve points that slow us down thereafter.  
+/// produces large curve points that slow us down thereafter.
 /// We do not require such divisions because we do not solve any
 /// system of equations and do not need ones on the diagonal.
 ///
-/// TODO: 
-/// We leave implementing this optimization to near future work 
+/// TODO:
+/// We leave implementing this optimization to near future work
 /// because it benifits from public keys being affine or having
-/// another hashable representation. 
+/// another hashable representation.
 ///
 ///
 /// As a curiosity, we note one interesting but suboptimal algorithm
@@ -316,8 +374,8 @@ pub fn verify_using_aggregated_auxiliary_public_keys<E: EngineBLS>(signed: &pop:
 /// operations required to verify aggregated BLS signatures is the
 /// minimal bipartite edge cover, aka bipartite dimension, of the
 /// bipartite graph with vertices given by points on the two curves
-/// and edges given by desired pairings. 
-/// In general, this problem is NP-hard even to approximate. 
+/// and edges given by desired pairings.
+/// In general, this problem is NP-hard even to approximate.
 /// See:  https://en.wikipedia.org/wiki/Bipartite_dimension
 ///
 /// There are polynomial time algorithms for bipartite edge cover in

--- a/src/verifiers.rs
+++ b/src/verifiers.rs
@@ -7,14 +7,21 @@ use core::borrow::Borrow;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
-use ark_ec::{AffineRepr, CurveGroup};
+#[cfg(feature = "std")]
+use ark_ec::{AffineRepr};
+#[cfg(feature = "std")]
 use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
+#[cfg(feature = "std")]
 use ark_serialize::CanonicalSerialize;
-
-use alloc::{vec, vec::Vec};
-
+#[cfg(feature = "std")]
 use digest::Digest;
+#[cfg(feature = "std")]
 use sha2::Sha256;
+
+use ark_ec::{CurveGroup};
+
+use alloc::{vec::Vec};
+
 
 use super::*;
 


### PR DESCRIPTION
- Remove Shake128 before hash to curve to be IETF standard compatible.
- Make DELQ challenge depends also on public key and message point.