### PR TITLE
Fix index out of bounds error in SecretKey::check() method

### DIFF
--- a/src/single.rs
+++ b/src/single.rs
@@ -381,7 +381,7 @@ where
 {
     fn check(&self) -> Result<(), SerializationError> {
         //TODO probabaly turn into vartime and check that because vartime impl valid
-        match (self.key[1].check(), self.key[2].check()) {
+        match (self.key[0].check(), self.key[1].check()) {
             (Ok(()), Ok(())) => Ok(()),
             _ => Err(SerializationError::InvalidData),
         }


### PR DESCRIPTION
- Changed self.key[1] and self.key[2] to self.key[0] and self.key[1]
- The key array has length 2, so indices 0 and 1 are valid
- This prevents runtime panic during validation operations